### PR TITLE
Add overlays for htop and proot-termux

### DIFF
--- a/modules/environment/login/default.nix
+++ b/modules/environment/login/default.nix
@@ -82,14 +82,7 @@ in
     environment.files = {
       inherit login loginInner;
 
-      prootStatic =
-        let
-          crossCompiledPaths = {
-           aarch64 = "/nix/store/r09n7pp4fwhrld2a1k2al6bgdx2qqfaj-proot-termux-unstable-2019-09-05-aarch64-unknown-linux-android";
-           i686 = "/nix/store/4gpm0rmrq0mm69kl3cb1gjslr7ihhp01-proot-termux-unstable-2019-09-05-i686-unknown-linux-android";
-          };
-        in
-          "${crossCompiledPaths.${config.build.arch}}";
+      prootStatic = pkgs.proot-termux;
     };
 
   };

--- a/modules/nixpkgs.nix
+++ b/modules/nixpkgs.nix
@@ -166,5 +166,7 @@ in
 
     _module.args.pkgs = _pkgs;
 
+    nixpkgs.overlays = import ../overlays;
+
   };
 }

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -2,4 +2,5 @@
 
 [
   (import ./htop.nix)
+  (import ./proot-termux.nix)
 ]

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -1,0 +1,5 @@
+# Copyright (c) 2019-2020, see AUTHORS. Licensed under MIT License, see LICENSE.
+
+[
+  (import ./htop.nix)
+]

--- a/overlays/htop.nix
+++ b/overlays/htop.nix
@@ -1,0 +1,18 @@
+# Copyright (c) 2019-2020, see AUTHORS. Licensed under MIT License, see LICENSE.
+
+self: super:
+
+let
+  nixpkgs = import ./lib/nixpkgs.nix { inherit super; };
+in
+
+{
+  htop = nixpkgs.htop.overrideAttrs (old: {
+    patches = [
+      (super.fetchpatch {
+        url = "https://raw.githubusercontent.com/termux/termux-packages/master/packages/htop/fix-missing-macros.patch";
+        sha256 = "1cljkjagp66xxcjb6y1m9k4v994slfkd0s6fijh02l3rp8ycvjnv";
+      })
+    ];
+  });
+}

--- a/overlays/lib/nixpkgs.nix
+++ b/overlays/lib/nixpkgs.nix
@@ -1,0 +1,17 @@
+# Copyright (c) 2019-2020, see AUTHORS. Licensed under MIT License, see LICENSE.
+
+{ super }:
+
+let
+  pinnedPkgsSrc = super.fetchFromGitHub {
+    owner = "NixOS";
+    repo = "nixpkgs";
+    rev = "7e8454fb856573967a70f61116e15f879f2e3f6a";
+    sha256 = "0lnbjjvj0ivpi9pxar0fyk8ggybxv70c5s0hpsqf5d71lzdpxpj8";
+  };
+in
+
+import pinnedPkgsSrc {
+  inherit (super) config;
+  overlays = [ ];
+}

--- a/overlays/proot-termux.nix
+++ b/overlays/proot-termux.nix
@@ -1,0 +1,68 @@
+# Copyright (c) 2019-2020, see AUTHORS. Licensed under MIT License, see LICENSE.
+
+self: super:
+
+let
+  nixpkgs = import ./lib/nixpkgs.nix { inherit super; };
+
+  talloc-static = nixpkgs.stdenv.mkDerivation rec {
+    name = "talloc-2.1.14";
+
+    src = nixpkgs.fetchurl {
+      url = "mirror://samba/talloc/${name}.tar.gz";
+      sha256 = "1kk76dyav41ip7ddbbf04yfydb4jvywzi2ps0z2vla56aqkn11di";
+    };
+
+    depsBuildBuild = [ nixpkgs.python2 nixpkgs.zlib ];
+
+    buildDeps = [ nixpkgs.zlib ];
+
+    configurePhase = ''
+      substituteInPlace buildtools/bin/waf \
+        --replace "/usr/bin/env python" "${nixpkgs.python2}/bin/python"
+      ./configure --prefix=$out \
+        --disable-rpath \
+        --disable-python \
+    '';
+
+    buildPhase = ''
+      make
+    '';
+
+    installPhase = ''
+      mkdir -p $out/lib
+      make install
+      gcc-ar q $out/lib/libtalloc.a bin/default/talloc_[0-9]*.o
+      rm -f $out/lib/libtalloc.so*
+    '';
+
+    fixupPhase = "";
+  };
+in
+
+{
+  proot-termux = nixpkgs.stdenv.mkDerivation rec {
+    pname = "proot-termux";
+    version = "unstable-2019-09-05";
+
+    src = nixpkgs.fetchFromGitHub {
+      repo = "proot";
+      owner = "termux";
+      rev = "3ea655b1ae40bfa2ee612d45bf1e7ad97c4559f8";
+      sha256 = "05y30ifbp4sn1pzy8wlifc5d9n2lrgspqzdjix1kxjj9j9947qgd";
+    };
+
+    buildInputs = [ talloc-static nixpkgs.llvm nixpkgs.glibc.static ];
+
+    CC = "llvm";
+    CFLAGS = "-D__ANDROID__";
+    LDFLAGS = "-static";
+    makeFlags = [ "-Csrc CFLAGS=-D__ANDROID__" ];
+
+    installPhase = ''
+      install -D -m 0755 src/proot $out/bin/proot-static
+    '';
+
+    fixupPhase = "";
+  };
+}

--- a/pkgs/nix-directory.nix
+++ b/pkgs/nix-directory.nix
@@ -1,6 +1,6 @@
 # Copyright (c) 2019-2020, see AUTHORS. Licensed under MIT License, see LICENSE.
 
-{ config, lib, stdenv, closureInfo, prootTermux, proot, qemuAarch64Static }:
+{ config, lib, stdenv, closureInfo, proot, qemuAarch64Static }:
 
 let
   buildRootDirectory = "root-directory";
@@ -16,10 +16,9 @@ let
     "-w /"
   ];
 
-  prootTermuxClosure = closureInfo {
+  initialClosure = closureInfo {
     rootPaths = [
       config.build.sessionInit
-      prootTermux
     ];
   };
 in
@@ -53,13 +52,13 @@ stdenv.mkDerivation {
     PKG_NIX=$(find ${buildRootDirectory}/nix/store -path '*/bin/nix' | sed 's,^${buildRootDirectory},,')
     PKG_NIX=''${PKG_NIX%/bin/nix}
 
-    for i in $(< ${prootTermuxClosure}/store-paths); do
+    for i in $(< ${initialClosure}/store-paths); do
       cp --archive "$i" "${buildRootDirectory}$i"
     done
 
     USER=${config.user.userName} ${prootCommand} "$PKG_NIX/bin/nix-store" --init
     USER=${config.user.userName} ${prootCommand} "$PKG_NIX/bin/nix-store" --load-db < .reginfo
-    USER=${config.user.userName} ${prootCommand} "$PKG_NIX/bin/nix-store" --load-db < ${prootTermuxClosure}/registration
+    USER=${config.user.userName} ${prootCommand} "$PKG_NIX/bin/nix-store" --load-db < ${initialClosure}/registration
 
     cat > package-info.nix <<EOF
     {


### PR DESCRIPTION
Hey, I am working on some overlays for htop for example. This works already, so I tried building proot on the device but if I run `nix-channel --update` I got an error like `Bus error` with an exit code of 135.

Do you have any idea, what might cause this?

Furthermore to provide a nice user experience, we need to build and push these packages with overlays to cachix. This is the reason for the pinned nixpkgs in the overlays to manually update the nixpkgs version to prevent rebuilds.

If an aarch64 build machine like in travis or github workflow really builds incompatible packages, we should consider using a custom android phone as build machine via hercules-ci or github workflow self-hosted runner.

What do you think?