### PR TITLE
Add support for different login shells

### DIFF
--- a/modules/environment/login/login-inner.nix
+++ b/modules/environment/login/login-inner.nix
@@ -69,6 +69,7 @@ writeText "login-inner" ''
   elif [ -x "${config.user.shell}" ]; then
     exec "${config.user.shell}"
   else
+    echo "Cannot execute shell '${config.user.shell}', falling back to bash"
     exec /usr/bin/env bash
   fi
 ''

--- a/modules/environment/login/login-inner.nix
+++ b/modules/environment/login/login-inner.nix
@@ -11,9 +11,10 @@ writeText "login-inner" ''
 
   set -eu -o pipefail
 
-  [ "$#" -gt 0 ] || echo "Welcome to Nix-on-Droid!"
-
-  [ "$#" -gt 0 ] || echo "If nothing works, open an issue at https://github.com/t184256/nix-on-droid/issues or try the rescue shell."
+  if [ "$#" -eq 0 ]; then  # if script is called from within nix-on-droid app
+    echo "Welcome to Nix-on-Droid!"
+    echo "If nothing works, open an issue at https://github.com/t184256/nix-on-droid/issues or try the rescue shell."
+  fi
 
   ${lib.optionalString config.build.initialBuild ''
     if [ -e /etc/UNINTIALISED ]; then
@@ -63,9 +64,11 @@ writeText "login-inner" ''
   . "${config.user.home}/.nix-profile/etc/profile.d/nix-on-droid-session-init.sh"
   set -u
 
-  if [ "$#" -eq 0 ]; then
-    exec /usr/bin/env bash
-  else
+  if [ "$#" -gt 0 ]; then  # if script is not called from within nix-on-droid app
     exec /usr/bin/env "$@"
+  elif [ -x "${config.user.shell}" ]; then
+    exec "${config.user.shell}"
+  else
+    exec /usr/bin/env bash
   fi
 ''

--- a/modules/user.nix
+++ b/modules/user.nix
@@ -40,7 +40,7 @@ in
 
       shell = mkOption {
         type = types.path;
-        readOnly = true;
+        default = "${pkgs.bashInteractive}/bin/bash";
         description = "Path to login shell.";
       };
 
@@ -73,7 +73,6 @@ in
     user = {
       group = "nix-on-droid";
       home = "/data/data/com.termux.nix/files/home";
-      shell = "/bin/sh";
       userName = "nix-on-droid";
     };
 

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -5,12 +5,16 @@
 let
   loadNixpkgs = import lib/load-nixpkgs.nix;
 
+  nixDirectory = callPackage ./nix-directory.nix { };
+  packageInfo = import "${nixDirectory}/nix-support/package-info.nix";
+
   nixpkgs = loadNixpkgs { };
 
   modules = import ../modules {
     pkgs = nixpkgs;
 
     config = {
+      user.shell = "${packageInfo.bash}/bin/bash";
       imports = [ ../modules/build/initial-build.nix ];
 
       _module.args = { inherit customPkgs; };
@@ -34,10 +38,9 @@ let
   );
 
   customPkgs = rec {
+    inherit nixDirectory packageInfo;
     bootstrap = callPackage ./bootstrap.nix { };
     bootstrapZip = callPackage ./bootstrap-zip.nix { };
-    nixDirectory = callPackage ./nix-directory.nix { };
-    packageInfo = import "${nixDirectory}/nix-support/package-info.nix";
     prootTermux = callPackage ./cross-compiling/proot-termux.nix { };
     qemuAarch64Static = callPackage ./qemu-aarch64-static.nix { };
     tallocStatic = callPackage ./cross-compiling/talloc-static.nix { };


### PR DESCRIPTION
This change allows to change the login shell through providing the full path to the binary.

In case the binary is not present or executable, bash will be run instead.

Through the failsafe shell it is possible to override the passwd and change the shell manually