### PR TITLE
Add source nix.sh and hm-session-vars.sh in session-init.sh

### DIFF
--- a/modules/environment/session-init.nix
+++ b/modules/environment/session-init.nix
@@ -19,6 +19,20 @@ let
       [ -n "$__NOD_SESS_INIT_SOURCED" ] && return
       export __NOD_SESS_INIT_SOURCED=1
 
+      . $HOME/.nix-profile/etc/profile.d/nix.sh
+
+      ${optionalString (config.home-manager.config != null) ''
+        if [ -e "$HOME/.nix-profile/etc/profile.d/hm-session-vars.sh" ]; then
+          export NIX_PATH=$HOME/.nix-defexpr/channels''${NIX_PATH:+:}$NIX_PATH
+          set +u
+          . "$HOME/.nix-profile/etc/profile.d/hm-session-vars.sh"
+          set -u
+        fi
+      ''}
+
+      # Workaround for https://github.com/NixOS/nix/issues/1865
+      export NIX_PATH=nixpkgs=$HOME/.nix-defexpr/channels/nixpkgs/:$NIX_PATH
+
       ${exportAll cfg.sessionVariables}
     '';
   };

--- a/pkgs/nix-directory.nix
+++ b/pkgs/nix-directory.nix
@@ -18,7 +18,6 @@ let
 
   prootTermuxClosure = closureInfo {
     rootPaths = [
-      config.build.sessionInit
       prootTermux
     ];
   };


### PR DESCRIPTION
With this change, everything to setup the session is separated into the session-init.sh. This has the advantage that when logged in via ssh, you only need to source one file, instead of up to 3.