### PR TITLE
home-manager 20.03 upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ for example:
 
 {
   environment.packages = [ pkgs.vim ];
-  system.stateVersion = "19.09";
+  system.stateVersion = "20.03";
 }
 ```
 
@@ -66,7 +66,7 @@ An alternative location is `~/.config/nixpkgs/config.nix` with the key
 
     {
       environment.packages = [ pkgs.vim ];
-      system.stateVersion = "19.09";
+      system.stateVersion = "20.03";
     };
 }
 ```
@@ -80,7 +80,7 @@ To enable `home-manager` you simply need to follow the instructions already prov
 
 1.  Add `home-manager` channel:
     ```
-    nix-channel --add https://github.com/rycee/home-manager/archive/release-19.09.tar.gz home-manager
+    nix-channel --add https://github.com/rycee/home-manager/archive/release-20.03.tar.gz home-manager
     nix-channel --update
     ```
 2.  Configure `home-manager`:

--- a/default.nix
+++ b/default.nix
@@ -38,8 +38,8 @@ rec {
       echo
       echo "Recommended: update with what you've used before (home-manager switch -or- nix-env -u)"
       echo
-      echo "Required if you've followed the steps above: set nix-on-droid channel to master"
-      echo "  nix-channel --add https://github.com/t184256/nix-on-droid/archive/master.tar.gz nix-on-droid"
+      echo "Required if you've followed the steps above: set nix-on-droid channel to release-20.03"
+      echo "  nix-channel --add https://github.com/t184256/nix-on-droid/archive/release-20.03.tar.gz nix-on-droid"
       echo
       echo "Finally,"
       echo "  nix-shell '<nix-on-droid>' -A migration"

--- a/default.nix
+++ b/default.nix
@@ -25,8 +25,8 @@ rec {
       is present) there is one manual step necessary *before* running the migration script: Remove basic-environment \
       package of 'home.packages' list."
       echo
-      echo "Recommended: change home-manager channel to release-19.09:"
-      echo "  nix-channel --add https://github.com/rycee/home-manager/archive/release-19.09.tar.gz home-manager"
+      echo "Recommended: change home-manager channel to release-20.03:"
+      echo "  nix-channel --add https://github.com/rycee/home-manager/archive/release-20.03.tar.gz home-manager"
       echo
       echo "Recommended: set nix-on-droid channel to a505862"
       echo "  nix-channel --add https://github.com/t184256/nix-on-droid/archive/pre-module-system.tar.gz nix-on-droid"
@@ -75,10 +75,10 @@ rec {
             ${pkgs.patch}/bin/patch --no-backup-if-mismatch $HOME/.config/nixpkgs/nix-on-droid.nix ${pkgs.writeText "patch" ''
               @@ -27,15 +27,9 @@
                  # Read the changelog before changing this value
-                 system.stateVersion = "19.09";
+                 system.stateVersion = "20.03";
 
               -  # After installing home-manager channel like
-              -  #   nix-channel --add https://github.com/rycee/home-manager/archive/release-19.09.tar.gz home-manager
+              -  #   nix-channel --add https://github.com/rycee/home-manager/archive/release-20.03.tar.gz home-manager
               -  #   nix-channel --update
               -  # you can configure home-manager in here like
               -  #home-manager.config =
@@ -97,10 +97,10 @@ rec {
             ${pkgs.patch}/bin/patch --no-backup-if-mismatch $HOME/.config/nixpkgs/nix-on-droid.nix ${pkgs.writeText "patch" ''
               @@ -27,15 +27,9 @@
                  # Read the changelog before changing this value
-                 system.stateVersion = "19.09";
+                 system.stateVersion = "20.03";
 
               -  # After installing home-manager channel like
-              -  #   nix-channel --add https://github.com/rycee/home-manager/archive/release-19.09.tar.gz home-manager
+              -  #   nix-channel --add https://github.com/rycee/home-manager/archive/release-20.03.tar.gz home-manager
               -  #   nix-channel --update
               -  # you can configure home-manager in here like
               -  #home-manager.config =

--- a/modules/build/initial-build.nix
+++ b/modules/build/initial-build.nix
@@ -19,7 +19,7 @@ with lib;
 
       nix-on-droid = mkOption {
         type = types.str;
-        default = "https://github.com/t184256/nix-on-droid/archive/master.tar.gz";
+        default = "https://github.com/t184256/nix-on-droid/archive/release-20.03.tar.gz";
         description = "Channel URL for nix-on-droid.";
       };
     };

--- a/modules/build/initial-build.nix
+++ b/modules/build/initial-build.nix
@@ -13,7 +13,7 @@ with lib;
     build.channel = {
       nixpkgs = mkOption {
         type = types.str;
-        default = "https://nixos.org/channels/nixos-19.09";
+        default = "https://nixos.org/channels/nixos-20.03";
         description = "Channel URL for nixpkgs.";
       };
 

--- a/modules/environment/login/nix-on-droid.nix.default
+++ b/modules/environment/login/nix-on-droid.nix.default
@@ -28,10 +28,10 @@
   environment.etcBackupExtension = ".bak";
 
   # Read the changelog before changing this value
-  system.stateVersion = "19.09";
+  system.stateVersion = "20.03";
 
   # After installing home-manager channel like
-  #   nix-channel --add https://github.com/rycee/home-manager/archive/release-19.09.tar.gz home-manager
+  #   nix-channel --add https://github.com/rycee/home-manager/archive/release-20.03.tar.gz home-manager
   #   nix-channel --update
   # you can configure home-manager in here like
   #home-manager.config =

--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -16,6 +16,7 @@ let
         imports = import <home-manager/modules/modules.nix> {
           inherit pkgs;
           lib = extendedLib;
+          useNixpkgsModule = !cfg.useGlobalPkgs;
         };
 
         config = {
@@ -52,6 +53,12 @@ in
         default = null;
         description = "Home Manager configuration.";
       };
+
+      useGlobalPkgs = mkEnableOption ''
+        using the system configuration's <literal>pkgs</literal>
+        argument in Home Manager. This disables the Home Manager
+        options <option>nixpkgs.*</option>
+      '';
 
       useUserPackages = mkEnableOption ''
         installation of user packages through the

--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -7,17 +7,27 @@ with lib;
 let
   cfg = config.home-manager;
 
-  hmModule = types.submodule ({ name, ... }: {
-    imports = import <home-manager/modules/modules.nix> { inherit lib pkgs; };
+  extendedLib = import <home-manager/modules/lib/stdlib-extended.nix> pkgs.lib;
 
-    config = {
-      submoduleSupport.enable = true;
-      submoduleSupport.externalPackageInstall = cfg.useUserPackages;
+  hmModule = types.submoduleWith {
+    specialArgs = { lib = extendedLib; };
+    modules = [
+      ({ name, ... }: {
+        imports = import <home-manager/modules/modules.nix> {
+          inherit pkgs;
+          lib = extendedLib;
+        };
 
-      home.username = config.user.userName;
-      home.homeDirectory = config.user.home;
-    };
-  });
+        config = {
+          submoduleSupport.enable = true;
+          submoduleSupport.externalPackageInstall = cfg.useUserPackages;
+
+          home.username = config.user.userName;
+          home.homeDirectory = config.user.home;
+        };
+      })
+    ];
+  };
 in
 
 {

--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -8,7 +8,9 @@ let
   cfg = config.home-manager;
 
   tryEval = builtins.tryEval <home-manager/modules/modules.nix>;
-  assertion = tryEval.success && builtins.functionArgs (import tryEval.value) ? useNixpkgsModule;
+  assertionNixpkgs = types ? submoduleWith;
+  assertionHomeManager = tryEval.success && builtins.functionArgs (import tryEval.value) ? useNixpkgsModule;
+  assertion = assertionNixpkgs && assertionHomeManager;
 
   extendedLib = import <home-manager/modules/lib/stdlib-extended.nix> pkgs.lib;
 
@@ -82,7 +84,12 @@ in
     {
       assertions = [
         {
-          inherit assertion;
+          assertion = assertionNixpkgs;
+          message = "You are currently using release-19.09 branch of nixpkgs, you need "
+            + "to update to the release-20.03 channel.";
+        }
+        {
+          assertion = assertionHomeManager;
           message = "You are currently using release-19.09 branch of home-manager, you need "
             + "to update to the release-20.03 channel.";
         }

--- a/modules/version.nix
+++ b/modules/version.nix
@@ -11,7 +11,7 @@ with lib;
   options = {
 
     system.stateVersion = mkOption {
-      type = types.enum [ "19.09" ];
+      type = types.enum [ "19.09" "20.03" ];
       default = "19.09";
       description = ''
         It is occasionally necessary for nix-on-droid to change


### PR DESCRIPTION
This PR introduces changes needed for the 20.03 release of home-manager. On 19.09 releases of home-manager this won't work.

Furthermore I added the useGlobalPkgs option recently introduced to home-manager.