### PR TITLE
Update packages

### DIFF
--- a/modules/environment/login/default.nix
+++ b/modules/environment/login/default.nix
@@ -85,8 +85,8 @@ in
       prootStatic =
         let
           crossCompiledPaths = {
-           aarch64 = "/nix/store/r09n7pp4fwhrld2a1k2al6bgdx2qqfaj-proot-termux-unstable-2019-09-05-aarch64-unknown-linux-android";
-           i686 = "/nix/store/4gpm0rmrq0mm69kl3cb1gjslr7ihhp01-proot-termux-unstable-2019-09-05-i686-unknown-linux-android";
+           aarch64 = "/nix/store/h27cfpnfzxv2m92bg9lsgpg6520cz0hz-proot-termux-unstable-2020-04-25-aarch64-unknown-linux-android";
+           i686 = "/nix/store/kz8lil7m0c4cjk2rv4skicalr31a47dv-proot-termux-unstable-2020-04-25-i686-unknown-linux-android";
           };
         in
           "${crossCompiledPaths.${config.build.arch}}";

--- a/overlays/lib/nixpkgs.nix
+++ b/overlays/lib/nixpkgs.nix
@@ -3,11 +3,12 @@
 { super }:
 
 let
+  # head of nixos-20.03 as of 2020-06-11
   pinnedPkgsSrc = super.fetchFromGitHub {
     owner = "NixOS";
     repo = "nixpkgs";
-    rev = "7e8454fb856573967a70f61116e15f879f2e3f6a";
-    sha256 = "0lnbjjvj0ivpi9pxar0fyk8ggybxv70c5s0hpsqf5d71lzdpxpj8";
+    rev = "8b071be7512bd2cd0ff5c3bdf60f01ab4eb94abd";
+    sha256 = "079rzd17y2pk48kh70pbp4a7mh56vi2b49lzd365ckh38gdv702z";
   };
 in
 

--- a/pkgs/cross-compiling/proot-termux.nix
+++ b/pkgs/cross-compiling/proot-termux.nix
@@ -8,13 +8,13 @@ in
 
 pkgs.crossStatic.stdenv.mkDerivation {
   pname = "proot-termux";
-  version = "unstable-2019-09-05";
+  version = "unstable-2020-04-25";
 
   src = fetchFromGitHub {
     repo = "proot";
     owner = "termux";
-    rev = "3ea655b1ae40bfa2ee612d45bf1e7ad97c4559f8";
-    sha256 = "05y30ifbp4sn1pzy8wlifc5d9n2lrgspqzdjix1kxjj9j9947qgd";
+    rev = "b9588b1edff5069118c50f2f9b19397fce39f5c7";
+    sha256 = "0izs2vqbn7zaa0fxwr78p1kaa4f3k9rhv4g94zsmw38cqlmidv56";
   };
 
   buildInputs = [ tallocStatic ];

--- a/pkgs/lib/load-nixpkgs.nix
+++ b/pkgs/lib/load-nixpkgs.nix
@@ -3,14 +3,27 @@
 let
   defaultNixpkgsArgs = {
     config = { };
-    overlays = [ ];
+    overlays = [
+      (self: super: {
+        gdb = super.gdb.override {
+          # actual default value of safePaths, but `lib` does not exist when cross-compiling:
+          # [
+          #   # $debugdir:$datadir/auto-load are whitelisted by default by GDB
+          #   "$debugdir" "$datadir/auto-load"
+          #   # targetPackages so we get the right libc when cross-compiling and using buildPackages.gdb
+          #   targetPackages.stdenv.cc.cc.lib
+          # ]
+          safePaths = [ "$debugdir" "$datadir/auto-load" ];
+        };
+      })
+    ];
   };
 
-  # head of nixos-19.09 as of 2019-11-28
+  # head of nixos-20.03 as of 2020-06-11
   # note: when updating nixpkgs, update store paths of proot-termux in modules/environment/login/default.nix
   pinnedPkgsSrc = builtins.fetchTarball {
-    url = "https://github.com/NixOS/nixpkgs/archive/73fb59dbb89ed5f754249761dcd99c6ccbd24bb5.tar.gz";
-    sha256 = "0fp85c907qw1qnxs40dx4yas9z5fqr9gszk4nazx90hwbimyk6n6";
+    url = "https://github.com/NixOS/nixpkgs/archive/8b071be7512bd2cd0ff5c3bdf60f01ab4eb94abd.tar.gz";
+    sha256 = "079rzd17y2pk48kh70pbp4a7mh56vi2b49lzd365ckh38gdv702z";
   };
 in
 

--- a/pkgs/nix-directory.nix
+++ b/pkgs/nix-directory.nix
@@ -27,12 +27,12 @@ stdenv.mkDerivation {
   name = "nix-directory";
 
   src = builtins.fetchurl {
-    url = "https://nixos.org/releases/nix/nix-2.3.1/nix-2.3.1-${config.build.arch}-linux.tar.xz";
+    url = "https://nixos.org/releases/nix/nix-2.3.6/nix-2.3.6-${config.build.arch}-linux.tar.xz";
     sha256 =
       let
         archShas = {
-         aarch64 = "94a6a525bd0b2df82e14b96b5b0eaae86669b5d4671aacfc4db2db85325a81c1";
-         i686 = "a5d3f26d4a449616bf654286f2fe29c1c1df4f029b7e29fa3ccf8494d598bfee";
+         aarch64 = "96bfea4540342c97b5337a707cf9c0f0d00028e443536a6a191ee61a169d5ecb";
+         i686 = "f2ec612c0f96c1e6129df570ac5dfc2045334554d2863b014618d67e05fa18fa";
         };
       in
         "${archShas.${config.build.arch}}";

--- a/pkgs/qemu-aarch64-static.nix
+++ b/pkgs/qemu-aarch64-static.nix
@@ -6,8 +6,8 @@ stdenv.mkDerivation {
   name = "qemu-aarch64-static";
 
   src = builtins.fetchurl {
-    url = "https://github.com/multiarch/qemu-user-static/releases/download/v4.1.0-1/qemu-aarch64-static";
-    sha256 = "06491ivqjz1n4c391dvl8fzgkc82ijcgg7qz1fnjh0hks12fd85s";
+    url = "https://github.com/multiarch/qemu-user-static/releases/download/v5.0.0-2/qemu-aarch64-static";
+    sha256 = "0q4hxq7kfxm70wvqybrcr9db8akwlzxf5jljdxv4lff8ivlhr6rw";
   };
 
   unpackPhase = "true";


### PR DESCRIPTION
I tried to update some packages, but I get the following for nixpkgs upgrade, do you have any idea?

```
$> nix build -f ./pkgs --argstr arch aarch64 bootstrapZip --show-trace
error: while evaluating the attribute 'buildCommand' of the derivation 'bootstrap-zip' at /nix/store/j5nzal9kpz06bqx73gzqskzjcba43ba3-source/pkgs/build-support/trivial-builders.nix:7:14:
while evaluating the attribute 'buildCommand' of the derivation 'bootstrap' at /nix/store/j5nzal9kpz06bqx73gzqskzjcba43ba3-source/pkgs/build-support/trivial-builders.nix:7:14:
while evaluating the attribute 'buildPhase' of the derivation 'nix-directory' at /home/tobias/projects/nix-on-droid/pkgs/nix-directory.nix:28:3:
while evaluating the attribute 'exportReferencesGraph' of the derivation 'closure-info' at /nix/store/j5nzal9kpz06bqx73gzqskzjcba43ba3-source/pkgs/build-support/closure-info.nix:14:3:
while evaluating the attribute 'propagatedBuildInputs' of the derivation 'proot-termux-unstable-2019-09-05-aarch64-unknown-linux-android' at /nix/store/j5nzal9kpz06bqx73gzqskzjcba43ba3-source/pkgs/stdenv/generic/make-derivation.nix:197:11:
while evaluating the attribute 'buildDeps' of the derivation 'talloc-static-2.1.14-aarch64-unknown-linux-android' at /nix/store/j5nzal9kpz06bqx73gzqskzjcba43ba3-source/pkgs/stdenv/generic/make-derivation.nix:197:11:
while evaluating the attribute 'stdenv' of the derivation 'zlib-1.2.11-aarch64-unknown-linux-android' at /nix/store/j5nzal9kpz06bqx73gzqskzjcba43ba3-source/pkgs/stdenv/generic/make-derivation.nix:197:11:
while evaluating the attribute 'defaultNativeBuildInputs' of the derivation 'stdenv-linux' at /nix/store/j5nzal9kpz06bqx73gzqskzjcba43ba3-source/pkgs/stdenv/generic/default.nix:84:14:
while evaluating the attribute 'bintools' of the derivation 'aarch64-unknown-linux-android-ndk-gcc-binutils-wrapper-' at /nix/store/j5nzal9kpz06bqx73gzqskzjcba43ba3-source/pkgs/stdenv/generic/make-derivation.nix:191:11:
while evaluating the attribute 'bintools_bin' of the derivation 'aarch64-unknown-linux-android-ndk-gcc-binutils-wrapper-' at /nix/store/j5nzal9kpz06bqx73gzqskzjcba43ba3-source/pkgs/stdenv/generic/make-derivation.nix:191:11:
while evaluating the attribute 'buildCommand' of the derivation 'ndk-gcc-binutils' at /nix/store/j5nzal9kpz06bqx73gzqskzjcba43ba3-source/pkgs/build-support/trivial-builders.nix:7:14:
while evaluating the attribute 'installPhase' of the derivation 'ndk-bundle-18.1.5063045' at /nix/store/j5nzal9kpz06bqx73gzqskzjcba43ba3-source/pkgs/development/mobile/androidenv/deploy-androidpackage.nix:8:3:
while evaluating 'optionalString' at /nix/store/j5nzal9kpz06bqx73gzqskzjcba43ba3-source/lib/strings.nix:180:5, called from /nix/store/j5nzal9kpz06bqx73gzqskzjcba43ba3-source/pkgs/development/mobile/androidenv/ndk-bundle/default.nix:10:23:
while evaluating 'makeSearchPathOutput' at /nix/store/j5nzal9kpz06bqx73gzqskzjcba43ba3-source/lib/strings.nix:142:5, called from /nix/store/j5nzal9kpz06bqx73gzqskzjcba43ba3-source/pkgs/development/mobile/androidenv/ndk-bundle/default.nix:4:19:
while evaluating 'makeSearchPath' at /nix/store/j5nzal9kpz06bqx73gzqskzjcba43ba3-source/lib/strings.nix:122:5, called from /nix/store/j5nzal9kpz06bqx73gzqskzjcba43ba3-source/lib/strings.nix:142:11:
while evaluating anonymous function at /nix/store/j5nzal9kpz06bqx73gzqskzjcba43ba3-source/lib/strings.nix:123:32, called from undefined position:
while evaluating the attribute 'buildInputs' of the derivation 'openjdk-8u222-ga' at /nix/store/j5nzal9kpz06bqx73gzqskzjcba43ba3-source/pkgs/stdenv/generic/make-derivation.nix:191:11:
while evaluating the attribute 'buildInputs' of the derivation 'cups-2.3.1' at /nix/store/j5nzal9kpz06bqx73gzqskzjcba43ba3-source/pkgs/stdenv/generic/make-derivation.nix:191:11:
while evaluating the attribute 'preFixup' of the derivation 'libusb-1.0.23' at /nix/store/j5nzal9kpz06bqx73gzqskzjcba43ba3-source/pkgs/stdenv/generic/make-derivation.nix:191:11:
while evaluating 'optionalString' at /nix/store/j5nzal9kpz06bqx73gzqskzjcba43ba3-source/lib/strings.nix:180:5, called from /nix/store/j5nzal9kpz06bqx73gzqskzjcba43ba3-source/pkgs/development/libraries/libusb1/default.nix:31:14:
while evaluating the attribute 'nativeBuildInputs' of the derivation 'systemd-243.7' at /nix/store/j5nzal9kpz06bqx73gzqskzjcba43ba3-source/pkgs/stdenv/generic/make-derivation.nix:191:11:
while evaluating the attribute 'passAsFile' of the derivation 'python3-3.7.6-env' at /nix/store/j5nzal9kpz06bqx73gzqskzjcba43ba3-source/pkgs/build-support/trivial-builders.nix:7:14:
while evaluating 'requiredPythonModules' at /nix/store/j5nzal9kpz06bqx73gzqskzjcba43ba3-source/pkgs/top-level/python-packages.nix:64:27, called from /nix/store/j5nzal9kpz06bqx73gzqskzjcba43ba3-source/pkgs/development/interpreters/python/wrapper.nix:15:13:
while evaluating 'unique' at /nix/store/j5nzal9kpz06bqx73gzqskzjcba43ba3-source/lib/lists.nix:643:12, called from /nix/store/j5nzal9kpz06bqx73gzqskzjcba43ba3-source/pkgs/top-level/python-packages.nix:66:6:
while evaluating 'unique' at /nix/store/j5nzal9kpz06bqx73gzqskzjcba43ba3-source/lib/lists.nix:643:12, called from /nix/store/j5nzal9kpz06bqx73gzqskzjcba43ba3-source/lib/lists.nix:649:17:
while evaluating anonymous function at /nix/store/j5nzal9kpz06bqx73gzqskzjcba43ba3-source/lib/lists.nix:152:16, called from undefined position:
while evaluating the attribute 'outPath' at /nix/store/j5nzal9kpz06bqx73gzqskzjcba43ba3-source/lib/customisation.nix:159:7:
while evaluating the attribute 'nativeBuildInputs' of the derivation 'python3.7-lxml-4.4.2' at /nix/store/j5nzal9kpz06bqx73gzqskzjcba43ba3-source/pkgs/development/interpreters/python/mk-python-derivation.nix:105:3:
while evaluating the attribute 'out.outPath' at /nix/store/j5nzal9kpz06bqx73gzqskzjcba43ba3-source/lib/customisation.nix:151:13:
while evaluating the attribute 'buildInputs' of the derivation 'python3.7-Cython-0.29.14' at /nix/store/j5nzal9kpz06bqx73gzqskzjcba43ba3-source/pkgs/development/interpreters/python/mk-python-derivation.nix:105:3:
while evaluating the attribute 'configureFlags' of the derivation 'aarch64-unknown-linux-android-gdb-8.3.1' at /nix/store/j5nzal9kpz06bqx73gzqskzjcba43ba3-source/pkgs/development/tools/misc/gdb/default.nix:27:3:
while evaluating the attribute 'stdenv.cc.cc.lib' at /nix/store/j5nzal9kpz06bqx73gzqskzjcba43ba3-source/pkgs/build-support/cc-wrapper/default.nix:102:10:
attribute 'lib' missing, at /nix/store/j5nzal9kpz06bqx73gzqskzjcba43ba3-source/pkgs/development/tools/misc/gdb/default.nix:15:4
```