### PR TITLE
Add `useUserPackages` documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ To enable `home-manager` you simply need to follow the instructions already prov
       home-manager.config = import ./home.nix;
     }
     ```
+3.  Allow `home-manager` to reolve conflicts automatically (optional):
+    ```nix
+    home-manager.useUserPackages = true;
+    ```
 
 ### `nix-on-droid` executable
 

--- a/modules/environment/login/nix-on-droid.nix.default
+++ b/modules/environment/login/nix-on-droid.nix.default
@@ -39,6 +39,10 @@
   #  {
   #    # insert home-manager config
   #  };
+
+  # To avoid the `same priority` conflicts,
+  # you can set
+  #home-manager.useUserPackages = true;
 }
 
 # vim: ft=nix


### PR DESCRIPTION
Add `#home-manager.useUserPackages`
and explanation
to `nix-on-droid.nix.default` and `README.md`

If applied, users will be able to resolve package conflicts and make `home-manager` work more easily.

Solve issue #65