### PR TITLE
use the same nixpkgs

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -19,7 +19,7 @@ let
         _module.args.pkgs = mkDefault pkgs;
       }
       configModule
-    ] ++ import ./module-list.nix;
+    ] ++ import ./module-list.nix { inherit pkgs; };
   };
 
   failedAssertions = map (x: x.message) (filter (x: !x.assertion) rawModule.config.assertions);

--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -1,5 +1,7 @@
 # Copyright (c) 2019-2020, see AUTHORS. Licensed under MIT License, see LICENSE.
 
+{ pkgs }:
+
 [
   ./build/activation.nix
   ./build/config.nix
@@ -15,5 +17,5 @@
   ./user.nix
   ./version.nix
   ./workaround-make.nix
-  <nixpkgs/nixos/modules/misc/assertions.nix>
+  (pkgs.path + "/nixos/modules/misc/assertions.nix")
 ]


### PR DESCRIPTION
I have no idea how to change the one at:

https://github.com/t184256/nix-on-droid/blob/2fba450df011a0316de2d6013784c02a79ff1e22/modules/nixpkgs.nix#L57-L59

https://github.com/t184256/nix-on-droid/blob/2fba450df011a0316de2d6013784c02a79ff1e22/modules/nixpkgs.nix#L165-L171

I get some infinite recursion if I change it to `_module.args.pkgs = pkgs;`