### PR TITLE
user: allow to set uid/gid

### DIFF
--- a/modules/user.nix
+++ b/modules/user.nix
@@ -10,8 +10,8 @@ let
   idsDerivation = pkgs.runCommandLocal "ids.nix" {} ''
     cat > $out <<EOF
     {
-      gid = "$(${pkgs.coreutils}/bin/id -g)";
-      uid = "$(${pkgs.coreutils}/bin/id -u)";
+      gid = "${toString cfg.gid}";
+      uid = "${toString cfg.uid}";
     }
     EOF
   '';
@@ -48,6 +48,18 @@ in
         type = types.str;
         readOnly = true;
         description = "User name.";
+      };
+
+      uid = mkOption {
+        type = types.int;
+        default = toInt "$(${pkgs.coreutils}/bin/id -u)";
+        description = "Uid.";
+      };
+
+      gid = mkOption {
+        type = types.int;
+        default = toInt "$(${pkgs.coreutils}/bin/id -g)";
+        description = "Gid.";
       };
     };
 


### PR DESCRIPTION
> Also, just a thought: a simple, though hackish way would be to pick up uid/gid from the configuration file, and only go the idDerivation way if it's not there. This way "external" building won't have to be parametrized externally.

https://github.com/t184256/nix-on-droid/pull/97#issuecomment-761821403

@t184256 would this simple PR work? I didn't do any "and only go the idDerivation way if it's not there" thing.