### PR TITLE
flake.nix: fix overlays

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -10,12 +10,18 @@
   };
 
   outputs = { self, nixpkgs, home-manager, flake-utils }:
+    {
+      overlays = import ./overlays;
+    } //
     flake-utils.lib.eachSystem [
       "aarch64-linux"
       "i686-linux"
     ]
       (system:
-        let pkgs = nixpkgs.legacyPackages.${system}; in
+        let pkgs = import nixpkgs {
+          inherit system;
+          overlays = self.overlays;
+        }; in
         rec {
           lib = {
             nix-on-droid = { config }: import ./modules {
@@ -24,8 +30,6 @@
               home-manager = (import home-manager { });
             };
           };
-
-          overlays = ./overlays;
 
           apps.nix-on-droid = flake-utils.lib.mkApp {
             drv = (pkgs.callPackage ./nix-on-droid { });


### PR DESCRIPTION
With this change, the overlays are used when using flakes.

related to https://github.com/t184256/nix-on-droid/issues/94#issuecomment-850849580