### PR TITLE
overlays/lib/nixpkgs.nix: use system

### DIFF
--- a/overlays/lib/nixpkgs.nix
+++ b/overlays/lib/nixpkgs.nix
@@ -13,6 +13,6 @@ let
 in
 
 import pinnedPkgsSrc {
-  inherit (super) config;
+  inherit (super) config system;
   overlays = [ ];
 }


### PR DESCRIPTION
Any idea what to do with this:

https://github.com/t184256/nix-on-droid/blob/78d349eecc2382b65c6d93f4ef15d5588db169c6/modules/nixpkgs.nix#L169

Does non-flake use `system`?

EDIT: maybe `{ system ? builtins.currentSystem }:`