### PR TITLE
Backport to 21.05 option `nix.package`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 * The `/etc/nix/nix.conf` file is now fully configurable with the
   new options `nix.*`.
 
+* [Backport from 21.11] The `nix.package` can be used to set the system-wide nix package.
+
 ### Deprecations
 
 * `system.workaround.make-posix-spawn.enable = true;` is no longer needed

--- a/modules/build/activation.nix
+++ b/modules/build/activation.nix
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2020, see AUTHORS. Licensed under MIT License, see LICENSE.
+# Copyright (c) 2019-2021, see AUTHORS. Licensed under MIT License, see LICENSE.
 
 { config, lib, pkgs, ... }:
 
@@ -19,7 +19,7 @@ let
     pkgs.gnugrep
     pkgs.gnused
     pkgs.ncurses          # For `tput`.
-    pkgs.nix
+    config.nix.package
   ];
 
   mkActivationCmds = activation: concatStringsSep "\n" (

--- a/modules/environment/nix.nix
+++ b/modules/environment/nix.nix
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2020, see AUTHORS. Licensed under MIT License, see LICENSE.
+# Copyright (c) 2019-2021, see AUTHORS. Licensed under MIT License, see LICENSE.
 
 { config, lib, pkgs, ... }:
 
@@ -15,6 +15,15 @@ in
   options = {
 
     nix = {
+      package = mkOption {
+        type = types.package;
+        default = pkgs.nix;
+        defaultText = "pkgs.nix";
+        description = ''
+          This option specifies the Nix package instance to use throughout the system.
+        '';
+      };
+
       substituters = mkOption {
         type = types.listOf types.str;
         default = [];

--- a/modules/environment/path.nix
+++ b/modules/environment/path.nix
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2020, see AUTHORS. Licensed under MIT License, see LICENSE.
+# Copyright (c) 2019-2021, see AUTHORS. Licensed under MIT License, see LICENSE.
 
 { config, lib, pkgs, ... }:
 
@@ -42,12 +42,12 @@ in
 
     environment = {
       packages = [
-        (pkgs.callPackage ../../nix-on-droid { })
+        (pkgs.callPackage ../../nix-on-droid { nix = config.nix.package; })
         pkgs.bashInteractive
         pkgs.cacert
         pkgs.coreutils
         pkgs.less  # since nix tools really want a pager available, #27
-        pkgs.nix
+        config.nix.package
       ];
 
       path = pkgs.buildEnv {


### PR DESCRIPTION
Not sure if we do backports here, but it doesn't hurt.

**Motivation**

1.  NixOS/nixpkgs/release-21.05 is the current stable branch.
2.  The backport is backward-compatible. A similar option has been part of the NixOS configuration long before they are added here.
3.  There's no workaround to specify the Nix package to use without adding this option. This patch greatly increase the user experience for flake-based configuration (`nix.package = pkgs.nixUnstable;`).