### PR TITLE
activation.nix: fix for "activation from build result"

### DIFF
--- a/modules/build/activation.nix
+++ b/modules/build/activation.nix
@@ -133,7 +133,7 @@ in
         if [[ $generationDir =~ ^${profileDirectory}-([0-9]+)-link$ ]]; then
           $DRY_RUN_CMD nix-env --profile "${profileDirectory}" --switch-generation "''${BASH_REMATCH[1]}"
         else
-          $DRY_RUN_CMD nix-env --profile "${profileDirectory}" --set "$generationDir"
+          $DRY_RUN_CMD nix-env --profile "${profileDirectory}" --set "$(realpath "$generationDir")"
         fi
       '';
 


### PR DESCRIPTION
Set profile with the store path instead of the path of the "result" link.

Solve #111