### PR TITLE
Bind /dev/shm

### DIFF
--- a/modules/environment/login/login.nix
+++ b/modules/environment/login/login.nix
@@ -33,6 +33,7 @@ writeScript "login" ''
     -b ${installationDir}/bin:/bin \
     -b ${installationDir}/etc:/etc \
     -b ${installationDir}/tmp:/tmp \
+    -b ${installationDir}/tmp:/dev/shm \
     -b ${installationDir}/usr:/usr \
     -b /:/android \
     --link2symlink \


### PR DESCRIPTION
POSIX semaphores need /dev/shm to work. Without this, python
multiprocessing gives errors:

```
Traceback (most recent call last):
  ...
  File "/usr/lib/python2.7/multiprocessing/synchronize.py", line 75, in __init__
    sl = self._semlock = _multiprocessing.SemLock(kind, value, maxvalue)
OSError: [Errno 13] Permission denied
```