### PR TITLE
Remove set +u/-u

### DIFF
--- a/modules/environment/login/login-inner.nix
+++ b/modules/environment/login/login-inner.nix
@@ -60,9 +60,7 @@ writeText "login-inner" ''
     fi
   ''}
 
-  set +u
   . "${config.user.home}/.nix-profile/etc/profile.d/nix-on-droid-session-init.sh"
-  set -u
 
   ${lib.optionalString config.build.initialBuild ''
     exec /usr/bin/env bash  # otherwise it'll be a limited bash that came with Nix

--- a/modules/environment/session-init.nix
+++ b/modules/environment/session-init.nix
@@ -24,9 +24,7 @@ let
       ${optionalString (config.home-manager.config != null) ''
         if [ -e "$HOME/.nix-profile/etc/profile.d/hm-session-vars.sh" ]; then
           export NIX_PATH=$HOME/.nix-defexpr/channels''${NIX_PATH:+:}$NIX_PATH
-          set +u
           . "$HOME/.nix-profile/etc/profile.d/hm-session-vars.sh"
-          set -u
         fi
       ''}
 


### PR DESCRIPTION
Lots of zsh plugins fail to load when login via sshd:

```
$ ssh -p 8022 nix-on-droid@192.168.0.1
(eval):28: __zoxide_hooked: parameter not set
(eval):8: precmd_functions[(r)_direnv_hook]: parameter not set
async_init:1: ASYNC_INIT_DONE: parameter not set
prompt_pure_setup:10: prompt_newline: parameter not set
/nix/store/drwh7ngjshx794jvrvfvaz7wacjhkywi-zsh-fast-syntax-highlighting-1.54/share/zsh/site-functions/fast-syntax-highlighting.plugin.zsh:48: ZPLG_CUR_PLUGIN: parameter not set
```