### PR TITLE
Expose options

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -33,5 +33,5 @@ in
 
 {
   inherit (module.config.build) activationPackage;
-  inherit (module) config;
+  inherit (module) config options;
 }


### PR DESCRIPTION
Options are useful for documentation purposes and can be used by things like [nix-option](https://github.com/lucasew/nix-option) and automatic documentation generation systems.