### PR TITLE
flake.nix: Clean up, allow overriding pkgs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,9 +16,10 @@
       inherit system;
       overlays = [ self.overlay ];
     };
+    defaultHm = home-manager.outPath;
   in rec {
-    lib.nix-on-droid = { pkgs ? defaultPkgs, config }: import ./modules {
-      inherit pkgs home-manager config;
+    lib.nix-on-droid = { pkgs ? defaultPkgs, home-manager-path ? defaultHm, config }: import ./modules {
+      inherit pkgs home-manager-path config;
       isFlake = true;
     };
 

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -1,15 +1,11 @@
 # Copyright (c) 2019-2020, see AUTHORS. Licensed under MIT License, see LICENSE.
 
-{ pkgs ? import <nixpkgs> { }, home-manager ? <home-manager>, config ? null, isFlake ? false }:
+{ pkgs ? import <nixpkgs> { }, home-manager-path ? <home-manager>, config ? null, isFlake ? false }:
 
 with pkgs.lib;
 
 let
   defaultConfigFile = "${builtins.getEnv "HOME"}/.config/nixpkgs/nix-on-droid.nix";
-
-  hmPath = if home-manager ? install then
-    pkgs.lib.warn "Passing an initialized home-manager is useless - The overridden pkgs will not be used" home-manager.path
-  else home-manager;
 
   configModule =
     if config != null                             then config
@@ -20,7 +16,7 @@ let
   rawModule = evalModules {
     modules = [
       {
-        _module.args.home-manager = hmPath;
+        _module.args.home-manager-path = home-manager-path;
         _module.args.pkgs = mkDefault pkgs;
         _module.args.isFlake = isFlake;
       }

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -1,11 +1,15 @@
 # Copyright (c) 2019-2020, see AUTHORS. Licensed under MIT License, see LICENSE.
 
-{ pkgs ? import <nixpkgs> { }, home-manager ? import <home-manager> { }, config ? null, isFlake ? false }:
+{ pkgs ? import <nixpkgs> { }, home-manager ? <home-manager>, config ? null, isFlake ? false }:
 
 with pkgs.lib;
 
 let
   defaultConfigFile = "${builtins.getEnv "HOME"}/.config/nixpkgs/nix-on-droid.nix";
+
+  hmPath = if home-manager ? install then
+    pkgs.lib.warn "Passing an initialized home-manager is useless - The overridden pkgs will not be used" home-manager.path
+  else home-manager;
 
   configModule =
     if config != null                             then config
@@ -16,7 +20,7 @@ let
   rawModule = evalModules {
     modules = [
       {
-        _module.args.home-manager = home-manager;
+        _module.args.home-manager = hmPath;
         _module.args.pkgs = mkDefault pkgs;
         _module.args.isFlake = isFlake;
       }

--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -1,19 +1,19 @@
 # Copyright (c) 2019-2021, see AUTHORS. Licensed under MIT License, see LICENSE.
 
-{ config, lib, pkgs, home-manager, ... }:
+{ config, lib, pkgs, home-manager-path, ... }:
 
 with lib;
 
 let
   cfg = config.home-manager;
 
-  extendedLib = import (home-manager + "/modules/lib/stdlib-extended.nix") pkgs.lib;
+  extendedLib = import (home-manager-path + "/modules/lib/stdlib-extended.nix") pkgs.lib;
 
   hmModule = types.submoduleWith {
     specialArgs = { lib = extendedLib; };
     modules = [
       ({ name, ... }: {
-        imports = import (home-manager + "/modules/modules.nix") {
+        imports = import (home-manager-path + "/modules/modules.nix") {
           inherit pkgs;
           lib = extendedLib;
           useNixpkgsModule = !cfg.useGlobalPkgs;

--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -7,13 +7,13 @@ with lib;
 let
   cfg = config.home-manager;
 
-  extendedLib = import (home-manager.path + "/modules/lib/stdlib-extended.nix") pkgs.lib;
+  extendedLib = import (home-manager + "/modules/lib/stdlib-extended.nix") pkgs.lib;
 
   hmModule = types.submoduleWith {
     specialArgs = { lib = extendedLib; };
     modules = [
       ({ name, ... }: {
-        imports = import (home-manager.path + "/modules/modules.nix") {
+        imports = import (home-manager + "/modules/modules.nix") {
           inherit pkgs;
           lib = extendedLib;
           useNixpkgsModule = !cfg.useGlobalPkgs;


### PR DESCRIPTION
This allows `pkgs` and `home-manager` to be easily overridden for custom configs. We also fix the `overlay` output so that the output attribute set matches the standard schema (`nix flake check`).