### PR TITLE
More native flake support

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -1,6 +1,12 @@
 # Copyright (c) 2019-2020, see AUTHORS. Licensed under MIT License, see LICENSE.
 
-{ pkgs ? import <nixpkgs> { }, home-manager-path ? <home-manager>, config ? null, isFlake ? false }:
+{ config ? null
+, extraModules ? [ ]
+, extraSpecialArgs ? { }
+, pkgs ? import <nixpkgs> { }
+, home-manager-path ? <home-manager>
+, isFlake ? false
+}:
 
 with pkgs.lib;
 
@@ -16,12 +22,17 @@ let
   rawModule = evalModules {
     modules = [
       {
-        _module.args.home-manager-path = home-manager-path;
-        _module.args.pkgs = mkDefault pkgs;
-        _module.args.isFlake = isFlake;
+        _module.args =
+          {
+            inherit home-manager-path isFlake;
+            pkgs = mkDefault pkgs;
+          }
+          // extraSpecialArgs;
       }
       configModule
-    ] ++ import ./module-list.nix { inherit pkgs isFlake; };
+    ]
+    ++ extraModules
+    ++ import ./module-list.nix { inherit pkgs isFlake; };
   };
 
   failedAssertions = map (x: x.message) (filter (x: !x.assertion) rawModule.config.assertions);

--- a/nix-on-droid/default.nix
+++ b/nix-on-droid/default.nix
@@ -1,6 +1,6 @@
 # Copyright (c) 2019-2020, see AUTHORS. Licensed under MIT License, see LICENSE.
 
-{ bash, coreutils, nix, runCommand }:
+{ bash, coreutils, nix, nix_2_4, runCommand }:
 
 runCommand
   "nix-on-droid"
@@ -14,5 +14,6 @@ runCommand
     substituteInPlace $out/bin/nix-on-droid \
       --subst-var-by bash "${bash}" \
       --subst-var-by coreutils "${coreutils}" \
-      --subst-var-by nix "${nix}"
+      --subst-var-by nix "${nix}" \
+      --subst-var-by nix24 "${nix_2_4}"
   ''

--- a/nix-on-droid/nix-on-droid.sh
+++ b/nix-on-droid/nix-on-droid.sh
@@ -10,7 +10,7 @@ set -o pipefail
 PROFILE_DIRECTORY="/nix/var/nix/profiles/nix-on-droid"
 
 function errorEcho() {
-    >&2 echo $@
+    >&2 echo "$@"
 }
 
 function setupPasstroughOpts() {
@@ -190,7 +190,7 @@ case $COMMAND in
         ;;
     rollback)
         if [[ $(readlink $PROFILE_DIRECTORY) =~ ^nix-on-droid-([0-9]+)-link$ ]]; then
-            doSwitchGeneration $((${BASH_REMATCH[1]} - 1))
+            doSwitchGeneration $((BASH_REMATCH[1] - 1))
         else
             errorEcho "nix-on-droid profile link is broken, please run nix-on-droid switch to fix it."
             exit 1
@@ -201,7 +201,7 @@ case $COMMAND in
         ;;
     switch-generation)
         if [[ ${#COMMAND_ARGS[@]} -eq 1 ]]; then
-            doSwitchGeneration ${COMMAND_ARGS[0]}
+            doSwitchGeneration "${COMMAND_ARGS[0]}"
         else
             errorEcho "switch-generation expects one argument, got ${#COMMAND_ARGS[@]}."
             exit 1

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -3,23 +3,20 @@
 { arch, nixOnDroidChannelURL ? null, nixpkgsChannelURL ? null }:
 
 let
-  loadNixpkgs = import lib/load-nixpkgs.nix;
-
   nixDirectory = callPackage ./nix-directory.nix { };
   packageInfo = import "${nixDirectory}/nix-support/package-info.nix";
 
-  nixpkgs = loadNixpkgs { };
+  nixpkgs = import lib/load-nixpkgs.nix { };
 
   modules = import ../modules {
     pkgs = nixpkgs;
 
+    extraModules = [ ../modules/build/initial-build.nix ];
+    extraSpecialArgs = { inherit customPkgs; };
+
     config = {
       # Fix invoking bash after initial build.
       user.shell = "${packageInfo.bash}/bin/bash";
-
-      imports = [ ../modules/build/initial-build.nix ];
-
-      _module.args = { inherit customPkgs; };
 
       build = {
         inherit arch;
@@ -39,7 +36,7 @@ let
     }
   );
 
-  customPkgs = rec {
+  customPkgs = {
     inherit nixDirectory packageInfo;
     bootstrap = callPackage ./bootstrap.nix { };
     bootstrapZip = callPackage ./bootstrap-zip.nix { };

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -12,7 +12,10 @@ let
     pkgs = nixpkgs;
 
     extraModules = [ ../modules/build/initial-build.nix ];
-    extraSpecialArgs = { inherit customPkgs; };
+    extraSpecialArgs = {
+      inherit customPkgs;
+      pkgs = nixpkgs.lib.mkForce nixpkgs; # to override ./modules/nixpkgs/config.nix
+    };
 
     config = {
       # Fix invoking bash after initial build.

--- a/tests/fakedroid.sh
+++ b/tests/fakedroid.sh
@@ -52,7 +52,7 @@ PROOT_ARGS+=' --link2symlink'
 [[ -e .fakedroid/inj/qemu-aarch64 ]] || wget $QEMU_URL -O $QEMU
 chmod +x $QEMU
 
-PROOT=$(nix-build tests/proot-test.nix)/bin/proot
+PROOT=$(nix-build --no-out-link tests/proot-test.nix)/bin/proot
 
 
 # Do the first install if not installed yet:

--- a/tests/on-device/.run.sh
+++ b/tests/on-device/.run.sh
@@ -6,8 +6,11 @@
 set -ueo pipefail
 
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+PROFILE_DIRECTORY="/nix/var/nix/profiles/nix-on-droid"
+
 SELF_TEST_DIR="$HOME/.cache/nix-on-droid-self-test"
 CONFIRMATION_FILE="$SELF_TEST_DIR/confirmation-granted"
+DEFAULT_ACTIVATE_SCRIPT="$SELF_TEST_DIR/default-activate"
 mkdir -p "$SELF_TEST_DIR"
 
 if [[ ! -e "$CONFIRMATION_FILE" ]]; then
@@ -19,6 +22,10 @@ if [[ ! -e "$CONFIRMATION_FILE" ]]; then
     read -r CONFIRMATION
     if [[ "$CONFIRMATION" != 'I do' ]]; then echo 'Cool, aborting.'; exit 7; fi
     touch "$CONFIRMATION_FILE"
+fi
+
+if [[ ! -e "$DEFAULT_ACTIVATE_SCRIPT" ]]; then
+    ln -sn "$(readlink -f "$PROFILE_DIRECTORY/activate")" "$DEFAULT_ACTIVATE_SCRIPT"
 fi
 
 if [[ ! -d ~/.config.bak ]]; then

--- a/tests/on-device/.run.sh
+++ b/tests/on-device/.run.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#! nix-shell -i bash -p bats
+#! nix-shell -i bash -p bats ncurses
 
 # Copyright (c) 2019-2021, see AUTHORS. Licensed under MIT License, see LICENSE.
 
@@ -26,7 +26,7 @@ if [[ ! -d ~/.config.bak ]]; then
     cp -r ~/.config.bak ~/.config
 fi
 
-bats "${SCRIPT_DIR}" --verbose-run --timing
+bats "${SCRIPT_DIR}" --verbose-run --timing --pretty
 
 rm -rf ~/.config
 mv ~/.config.bak ~/.config

--- a/tests/on-device/.run.sh
+++ b/tests/on-device/.run.sh
@@ -28,12 +28,19 @@ if [[ ! -e "$DEFAULT_ACTIVATE_SCRIPT" ]]; then
     ln -sn "$(readlink -f "$PROFILE_DIRECTORY/activate")" "$DEFAULT_ACTIVATE_SCRIPT"
 fi
 
-if [[ ! -d ~/.config.bak ]]; then
-    mv ~/.config ~/.config.bak
-    cp -r ~/.config.bak ~/.config
+_cleanup() {
+    rm -rf ~/.config/nixpkgs
+    mv ~/.config/nixpkgs.bak ~/.config/nixpkgs
+}
+
+trap _cleanup SIGINT SIGTERM SIGKILL
+
+if [[ ! -d ~/.config/nixpkgs.bak ]]; then
+    mv ~/.config/nixpkgs ~/.config/nixpkgs.bak
 fi
+
+mkdir -p ~/.config/nixpkgs
 
 bats "${SCRIPT_DIR}" --verbose-run --timing --pretty
 
-rm -rf ~/.config
-mv ~/.config.bak ~/.config
+_cleanup

--- a/tests/on-device/config-default.bats
+++ b/tests/on-device/config-default.bats
@@ -4,4 +4,7 @@ load lib
 
 @test 'default config can be switched into' {
   switch_to_default_config
+
+  assert_command nix-on-droid nix-shell bash vi find
+  assert_no_command dash xonsh zsh
 }

--- a/tests/on-device/config-flake-h-m.bats
+++ b/tests/on-device/config-flake-h-m.bats
@@ -3,8 +3,7 @@
 load lib
 
 @test 'flake + h-m + #134 overlays case work' {
-  # start from a known baseline
-  switch_to_default_config
+  # assertions to verify initial state is as expected
   assert_command vi
   assert_no_command dash zsh
 

--- a/tests/on-device/config-flake-h-m.bats
+++ b/tests/on-device/config-flake-h-m.bats
@@ -24,7 +24,6 @@ load lib
   assert_no_command vi
 
   # check that reverting works too
-  rm -f ~/.config/nix/nix.conf ~/.config/nixpkgs/flake.nix
   switch_to_default_config
   assert_command vi
   assert_no_command dash zsh

--- a/tests/on-device/config-flake-h-m.bats
+++ b/tests/on-device/config-flake-h-m.bats
@@ -13,14 +13,8 @@ load lib
   _sed "s|<<FLAKE_URL>>|$FLAKE_URL|g" \
     "$ON_DEVICE_TESTS_DIR/config-flake-h-m.flake.nix" \
     > ~/.config/nixpkgs/flake.nix
-  pushd ~/.config/nixpkgs
-    nix-shell -p nixFlakes --run \
-      'nix build \
-        --extra-experimental-features nix-command \
-        --extra-experimental-features flakes \
-        --impure .#nix-on-droid'
-    result/activate
-  popd
+
+  nix-on-droid switch --flake ~/.config/nixpkgs#device
 
   # test presence of several crucial commands
   assert_command nix-on-droid nix-shell bash

--- a/tests/on-device/config-flake-h-m.bats
+++ b/tests/on-device/config-flake-h-m.bats
@@ -10,10 +10,9 @@ load lib
   # set up / build / activate the configuration
   cat "$ON_DEVICE_TESTS_DIR/config-flake-h-m.cfg.nix" \
     > ~/.config/nixpkgs/nix-on-droid.nix
-  nix-shell -p gnused --run \
-    "sed 's|<<FLAKE_URL>>|$FLAKE_URL|g' \
-         < '$ON_DEVICE_TESTS_DIR/config-flake-h-m.flake.nix' \
-         > ~/.config/nixpkgs/flake.nix"
+  _sed "s|<<FLAKE_URL>>|$FLAKE_URL|g" \
+    "$ON_DEVICE_TESTS_DIR/config-flake-h-m.flake.nix" \
+    > ~/.config/nixpkgs/flake.nix
   pushd ~/.config/nixpkgs
     nix-shell -p nixFlakes --run \
       'nix build \

--- a/tests/on-device/config-flake-h-m.flake.nix
+++ b/tests/on-device/config-flake-h-m.flake.nix
@@ -5,15 +5,16 @@
     nixpkgs.url = "github:NixOS/nixpkgs/release-21.11";
     home-manager.url = "github:nix-community/home-manager/release-21.11";
     nix-on-droid.url = "<<FLAKE_URL>>";
-
-    home-manager.inputs.nixpkgs.follows = "nixpkgs";
     nix-on-droid.inputs.nixpkgs.follows = "nixpkgs";
     nix-on-droid.inputs.home-manager.follows = "home-manager";
   };
 
   outputs = { nix-on-droid, ... }: {
-    nix-on-droid = (nix-on-droid.lib.aarch64-linux.nix-on-droid {
-      config = /data/data/com.termux.nix/files/home/.config/nixpkgs/nix-on-droid.nix;
-    }).activationPackage;
+    nixOnDroidConfigurations = {
+      device = nix-on-droid.lib.nixOnDroidConfiguration {
+        config = ./nix-on-droid.nix;
+        system = "aarch64-linux";
+      };
+    };
   };
 }

--- a/tests/on-device/config-flake.bats
+++ b/tests/on-device/config-flake.bats
@@ -28,7 +28,6 @@ load lib
   assert_no_command vi
 
   # check that reverting works too
-  rm -f ~/.config/nix/nix.conf ~/.config/nixpkgs/flake.nix
   switch_to_default_config
   assert_command vi
   assert_no_command unzip

--- a/tests/on-device/config-flake.bats
+++ b/tests/on-device/config-flake.bats
@@ -8,17 +8,15 @@ load lib
   assert_no_command unzip
 
   # set up / build / activate the configuration
-  nix-shell -p gnused --run \
-    "sed \
-         -e s/vim/nano/ \
-         -e s/#unzip/unzip/ \
-         < '$CHANNEL_DIR/modules/environment/login/nix-on-droid.nix.default' \
-         > ~/.config/nixpkgs/nix-on-droid.nix"
+  _sed \
+    -e 's/vim/nano/' \
+    -e 's/#unzip/unzip/' \
+    "$CHANNEL_DIR/modules/environment/login/nix-on-droid.nix.default" \
+    > ~/.config/nixpkgs/nix-on-droid.nix
 
-  nix-shell -p gnused --run \
-    "sed 's|<<FLAKE_URL>>|$FLAKE_URL|g' \
-         < '$ON_DEVICE_TESTS_DIR/config-flake.nix' \
-         > ~/.config/nixpkgs/flake.nix"
+  _sed "s|<<FLAKE_URL>>|$FLAKE_URL|g" \
+    "$ON_DEVICE_TESTS_DIR/config-flake.nix" \
+    > ~/.config/nixpkgs/flake.nix
 
   # this is more cumbersome than options,
   # but this is what we recommend to users, so taking the hard way

--- a/tests/on-device/config-flake.bats
+++ b/tests/on-device/config-flake.bats
@@ -18,13 +18,7 @@ load lib
     "$ON_DEVICE_TESTS_DIR/config-flake.nix" \
     > ~/.config/nixpkgs/flake.nix
 
-  # this is more cumbersome than options,
-  # but this is what we recommend to users, so taking the hard way
-  echo "experimental-features = nix-command flakes" >> ~/.config/nix/nix.conf
-  pushd ~/.config/nixpkgs
-    nix-shell -p nixFlakes --run 'nix build .#nix-on-droid --impure'
-    result/activate
-  popd
+  nix-on-droid switch --flake ~/.config/nixpkgs#device
 
   # test presence of several crucial commands
   assert_command nix-on-droid nix-shell bash

--- a/tests/on-device/config-flake.bats
+++ b/tests/on-device/config-flake.bats
@@ -3,11 +3,11 @@
 load lib
 
 @test 'flake example works' {
-  # start from a known baseline
-  switch_to_default_config
+  # assertions to verify initial state is as expected
   assert_command vi
-  assert_no_command dash unzip
+  assert_no_command unzip
 
+  # set up / build / activate the configuration
   nix-shell -p gnused --run \
     "sed \
          -e s/vim/nano/ \
@@ -39,5 +39,5 @@ load lib
   rm -f ~/.config/nix/nix.conf ~/.config/nixpkgs/flake.nix
   switch_to_default_config
   assert_command vi
-  assert_no_command dash unzip
+  assert_no_command unzip
 }

--- a/tests/on-device/config-flake.nix
+++ b/tests/on-device/config-flake.nix
@@ -8,8 +8,11 @@
   };
 
   outputs = { nix-on-droid, ... }: {
-    nix-on-droid = (nix-on-droid.lib.aarch64-linux.nix-on-droid {
-      config = /data/data/com.termux.nix/files/home/.config/nixpkgs/nix-on-droid.nix;
-    }).activationPackage;
+    nixOnDroidConfigurations = {
+      device = nix-on-droid.lib.nixOnDroidConfiguration {
+        config = ./nix-on-droid.nix;
+        system = "aarch64-linux";
+      };
+    };
   };
 }

--- a/tests/on-device/config-h-m.bats
+++ b/tests/on-device/config-h-m.bats
@@ -2,13 +2,17 @@
 
 load lib
 
+teardown() {
+  rm -f ~/.config/example
+}
+
 @test 'using home-manager works' {
-  # start from a known baseline
-  switch_to_default_config
+  # assertions to verify initial state is as expected
   assert_command vi
   assert_no_command dash
-  ! [[ -e ~/.config/example ]]
+  [[ ! -e ~/.config/example ]]
 
+  # set up / build / activate the configuration
   nix-channel --add https://github.com/rycee/home-manager/archive/release-21.11.tar.gz home-manager
   nix-channel --update
   cp "$ON_DEVICE_TESTS_DIR/config-h-m.nix" ~/.config/nixpkgs/nix-on-droid.nix
@@ -30,5 +34,11 @@ load lib
   [[ "$output" == success ]]
   [[ "$status" == 42 ]]
 
+  # check that reverting works too
   switch_to_default_config
+  assert_command vi
+  assert_no_command unzip
+
+  # file will be still present because home-manager needs to be set up to remove old links
+  [[ -e ~/.config/example ]]
 }

--- a/tests/on-device/config-h-m.bats
+++ b/tests/on-device/config-h-m.bats
@@ -2,7 +2,15 @@
 
 load lib
 
+setup() {
+  _setup
+  cp ~/.nix-channels ~/.nix-channels.bak
+}
+
 teardown() {
+  nix-channel --remove home-manager
+  mv ~/.nix-channels.bak ~/.nix-channels
+
   rm -f ~/.config/example
 }
 

--- a/tests/on-device/gnumake.bats
+++ b/tests/on-device/gnumake.bats
@@ -4,7 +4,9 @@
   TEMPDIR=/tmp/.tmp-gnumake.$$
   mkdir -p "$TEMPDIR"
   echo -e 'x:\n\techo desired output > x' > "$TEMPDIR/Makefile"
-  nix-shell -p gnumake --run "make -C $TEMPDIR x"
+
+  "$(nix-build "<nixpkgs>" --no-out-link --attr gnumake)/bin/make" -C "$TEMPDIR" x
+
   [[ -e "$TEMPDIR/x" ]]
   [[ "$(cat "$TEMPDIR/x")" == 'desired output' ]]
 }

--- a/tests/on-device/lib.bash
+++ b/tests/on-device/lib.bash
@@ -5,18 +5,19 @@ setup() {
     CHANNEL_DIR="$(nix-instantiate --eval --expr '<nix-on-droid>')"
     ON_DEVICE_TESTS_DIR="$CHANNEL_DIR/tests/on-device"
 
+    local channelUrl
     while read -r channel_line; do
       if [[ "$channel_line" =~ nix-on-droid[[:space:]]+(.*) ]]; then
-        CHANNEL_URL=${BASH_REMATCH[1]}
+        channelUrl=${BASH_REMATCH[1]}
       fi
     done < <(nix-channel --list)
-    echo "parsing detected channel url: $CHANNEL_URL"
-    if [[ "$CHANNEL_URL" =~ https://github.com/(.+)/(.+)/archive/(.+)\.tar\.gz ]]; then
-      REPO_USER=${BASH_REMATCH[1]}
-      REPO_NAME=${BASH_REMATCH[2]}
-      REPO_BRANCH=${BASH_REMATCH[3]}
-      FLAKE_URL=github:$REPO_USER/$REPO_NAME/$REPO_BRANCH
-    elif [[ "$CHANNEL_URL" == file:///n-o-d/archive.tar.gz ]]; then
+    echo "parsing detected channel url: $channelUrl"
+    if [[ "$channelUrl" =~ https://github.com/(.+)/(.+)/archive/(.+)\.tar\.gz ]]; then
+      local repoUser=${BASH_REMATCH[1]}
+      local repoName=${BASH_REMATCH[2]}
+      local repoBranch=${BASH_REMATCH[3]}
+      FLAKE_URL=github:$repoUser/$repoName/$repoBranch
+    elif [[ "$channelUrl" == file:///n-o-d/archive.tar.gz ]]; then
       FLAKE_URL=/n-o-d/unpacked
     fi
     echo "autodetected flake url: $FLAKE_URL"

--- a/tests/on-device/lib.bash
+++ b/tests/on-device/lib.bash
@@ -26,6 +26,7 @@ setup() {
 
   # restore to pre-testing generation before the start of each test
   $DEFAULT_ACTIVATE_SCRIPT
+  rm -rf ~/.config/nixpkgs/*
 
   # build and activate the version of nix-on-droid that is subject to test
   switch_to_default_config
@@ -45,8 +46,6 @@ assert_no_command() {
 }
 
 switch_to_default_config() {
-  rm -rf ~/.config/nix ~/.config/nixpkgs
-  mkdir -p ~/.config/nix ~/.config/nixpkgs
   cat "$CHANNEL_DIR/modules/environment/login/nix-on-droid.nix.default" \
     > ~/.config/nixpkgs/nix-on-droid.nix
   nix-on-droid switch

--- a/tests/on-device/lib.bash
+++ b/tests/on-device/lib.bash
@@ -51,3 +51,9 @@ switch_to_default_config() {
     > ~/.config/nixpkgs/nix-on-droid.nix
   nix-on-droid switch
 }
+
+_sed() {
+  local storePath
+  storePath="$(nix-build "<nixpkgs>" --no-out-link --attr gnused)"
+  "${storePath}/bin/sed" "$@"
+}

--- a/tests/on-device/lib.bash
+++ b/tests/on-device/lib.bash
@@ -26,6 +26,9 @@ setup() {
 
   # restore to pre-testing generation before the start of each test
   $DEFAULT_ACTIVATE_SCRIPT
+
+  # build and activate the version of nix-on-droid that is subject to test
+  switch_to_default_config
 }
 
 assert_command() {
@@ -47,7 +50,4 @@ switch_to_default_config() {
   cat "$CHANNEL_DIR/modules/environment/login/nix-on-droid.nix.default" \
     > ~/.config/nixpkgs/nix-on-droid.nix
   nix-on-droid switch
-
-  assert_command nix-on-droid nix-shell bash vi find
-  assert_no_command dash xonsh zsh
 }

--- a/tests/on-device/lib.bash
+++ b/tests/on-device/lib.bash
@@ -1,6 +1,7 @@
 # Copyright (c) 2019-2021, see AUTHORS. Licensed under MIT License, see LICENSE.
 
-setup() {
+# call _setup when defining a setup function in your test
+_setup() {
   if [[ -z "$ON_DEVICE_TESTS_SETUP" ]]; then
     CHANNEL_DIR="$(nix-instantiate --eval --expr '<nix-on-droid>')"
     ON_DEVICE_TESTS_DIR="$CHANNEL_DIR/tests/on-device"
@@ -31,6 +32,10 @@ setup() {
 
   # build and activate the version of nix-on-droid that is subject to test
   switch_to_default_config
+}
+
+setup() {
+  _setup
 }
 
 assert_command() {

--- a/tests/on-device/lib.bash
+++ b/tests/on-device/lib.bash
@@ -23,6 +23,9 @@ setup() {
 
     ON_DEVICE_TESTS_SETUP=1
   fi
+
+  # restore to pre-testing generation before the start of each test
+  $DEFAULT_ACTIVATE_SCRIPT
 }
 
 assert_command() {


### PR DESCRIPTION
This is my first draft of a more native integration of flakes support including

* conventions for `nixOnDroidConfigurations` and `nixOnDroidModules` flake outputs
* support for flakes in `nix-on-droid` tool
* support for `extraModules` and `extraSpecialArgs` similar to `home-manager` and `NixOS`

Any feedback on the API and documentation would be appreciated. The actual code changes are not tested yet, but the earlier I get feedback on my main ideas the better :)

This one supersedes https://github.com/t184256/nix-on-droid/pull/145, incorporating all its changes. The reason to not wait for its merge is to only change the `lib` output of the `nix-on-droid` once and I wanted these fields like `extraModules` and `extraSpecialArgs` in there :)

Ping @zhaofengli @ShamrockLee @bbigras as you were involved in flake related stuff lately in nix-on-droid, maybe you want to have a look at that too, to finish the first experimental native flake support.