### PR TITLE
ci: do not attempt to push to cachix on PR builds

### DIFF
--- a/.github/workflows/fakedroid-odt.yml
+++ b/.github/workflows/fakedroid-odt.yml
@@ -30,5 +30,5 @@ jobs:
         tests/fakedroid.sh nix-on-droid on-device-test
 
     - name: upload
-      if: always()
+      if: always() && github.event_name != 'pull_request'
       run: tests/fakedroid.sh nix-shell -p cachix --run 'nix path-info --all | cachix push nix-on-droid'


### PR DESCRIPTION
Secrets are not available when triggered by a PR. Therefore, `CACHIX_SIGNING_KEY` is not defined and cachix will always fail.