### PR TITLE
modules/build/activation.nix: fix missing /dev/shm on upgrade

### DIFF
--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -17,6 +17,7 @@
   ./home-manager.nix
   ./nixpkgs/options.nix
   ./time.nix
+  ./upgrade.nix
   ./user.nix
   ./version.nix
   (pkgs.path + "/nixos/modules/misc/assertions.nix")

--- a/modules/upgrade.nix
+++ b/modules/upgrade.nix
@@ -1,0 +1,15 @@
+# Copyright (c) 2019-2021, see AUTHORS. Licensed under MIT License, see LICENSE.
+
+{ config, lib, ... }:
+
+{
+  config.build.activationAfter =
+    # TODO: remove when we stop supporting upgrades from <21.11
+    # Setups upgraded to 21.11 don't have the /dev/shm directory bootstrapped:
+    # https://github.com/t184256/nix-on-droid/issues/162
+    lib.mkIf (lib.versionOlder config.system.stateVersion "21.11") {
+      createDevShm = ''
+        mkdir -p ${config.build.installationDir}/dev/shm
+      '';
+    };
+}


### PR DESCRIPTION
Fixes: #162

I plan for this to be the last MR going into the release, I haven't find other issues during upgrade testing.

Activation-time quick fix was chosen over login-time quick fix because I can imagine a hot loop around login, but activation is slow in comparison.