### PR TITLE
module/nix: Add backward compat with nixos for binary caches

### DIFF
--- a/modules/environment/nix.nix
+++ b/modules/environment/nix.nix
@@ -6,9 +6,16 @@ with lib;
 
 let
   cfg = config.nix;
+  renameNixOpt = old: new:
+    (mkRenamedOptionModule [ "nix" old ] [ "nix" new ]);
 in
 
 {
+  # Backward-compatibility with the NixOS options.
+  imports = [
+    (renameNixOpt "binaryCaches" "substituters")
+    (renameNixOpt "binaryCachePublicKeys" "trustedPublicKeys")
+  ];
 
   ###### interface
 


### PR DESCRIPTION
Per #166, complete compatibility with NixOS is a non-goal, and nix-on-droid options won't be renamed to match.

But it won't hurt to add compatibility where possible, and it's much simpler to do so here than to try to make the rest of the world change.