### PR TITLE
fix: don't force the use of nix_2_4 for flakes when nix is new enough

### DIFF
--- a/nix-on-droid/default.nix
+++ b/nix-on-droid/default.nix
@@ -1,6 +1,6 @@
 # Copyright (c) 2019-2020, see AUTHORS. Licensed under MIT License, see LICENSE.
 
-{ bash, coreutils, nix, nix_2_4, runCommand }:
+{ bash, coreutils, lib, nix, nix_2_4, runCommand }:
 
 runCommand
   "nix-on-droid"
@@ -15,5 +15,5 @@ runCommand
       --subst-var-by bash "${bash}" \
       --subst-var-by coreutils "${coreutils}" \
       --subst-var-by nix "${nix}" \
-      --subst-var-by nix24 "${nix_2_4}"
+      --subst-var-by nixge24 "${if lib.versionAtLeast nix.version "2.4pre" then nix else nix_2_4}"
   ''

--- a/nix-on-droid/nix-on-droid.sh
+++ b/nix-on-droid/nix-on-droid.sh
@@ -28,7 +28,7 @@ function nixActivationPackage() {
     local extraArgs=("${@:2}" "${PASSTHROUGH_OPTS[@]}")
     local nix=nix
     if [[ -n "${FLAKE_CONFIG_URI}" ]]; then
-        nix=@nix24@/bin/nix
+        nix=@nixge24@/bin/nix
         extraArgs+=(--impure "${FLAKE_CONFIG_URI}.activationPackage")
     else
         extraArgs+=(--file "<nix-on-droid/modules>" activationPackage)


### PR DESCRIPTION
This pull request updates the nix-on-droid derivation so it doesn't force `nix_2_4` when the `nix` package is newer than `2.4pre`. This allows people using more recent channels like nixpkgs-unstable to evaluate their flake configurations using the latest version of nix, while ensuring that those using older nix versions can still evaluate flakes (I believe 2.4 is the first version that supported flakes?).

I have tested this change using the following flake:

```nix
{
  description = "CHANGEME";

  inputs = {
    nixpkgs.url = "nixpkgs/release-21.11";
    # nixpkgs.url = "nixpkgs/release-22.05";
    utils.url = "github:numtide/flake-utils";
    nix-on-droid = {
      url = "github:mtoohey31/nix-on-droid/dont-force-nix_2_4";
      inputs = {
        flake-utils.follows = "utils";
        nixpkgs.follows = "nixpkgs";
      };
    };
  };

  outputs = { self, nixpkgs, nix-on-droid, utils }:
    utils.lib.eachDefaultSystem (system:
      with import nixpkgs { inherit system; };
      {
        devShells.default = mkShell {
          packages = [
            nix
            nix-on-droid.defaultApp.aarch64-linux.program
          ];
        };
      });
}
```

While `devShells.default` fails to build completely on my `x86_64-linux`, the important part is that the `nix-on-droid` executable (whose path is helpfully provided by the build error) references `nix-2.4` when the nixpkgs version is set to 21.11, but references 2.8.1 when the nixpkgs version is set to 22.05, since the version of the `nix` package for 21.11 is 2.3.16, and the version of the `nix` package for 22.05 is 2.8.1.

Closes #183.