### PR TITLE
Bump bootstrap nix to 2.11.0

### DIFF
--- a/pkgs/bootstrap.nix
+++ b/pkgs/bootstrap.nix
@@ -14,7 +14,6 @@ runCommand "bootstrap" { } ''
   chmod --recursive u+w $out/nix
 
   ln --symbolic ${packageInfo.bash}/bin/sh $out/bin/sh
-  ln --symbolic ${packageInfo.coreutils}/bin/env $out/usr/bin/env
 
   install -D -m 0755 ${prootTermux}/bin/proot-static $out/bin/proot-static
 

--- a/pkgs/nix-directory.nix
+++ b/pkgs/nix-directory.nix
@@ -36,8 +36,6 @@ stdenv.mkDerivation {
     CACERT=$(find ${buildRootDirectory}/nix/store -path '*-nss-cacert-*/ca-bundle.crt' | sed 's,^${buildRootDirectory},,')
     PKG_BASH=$(find ${buildRootDirectory}/nix/store -path '*/bin/bash' | sed 's,^${buildRootDirectory},,')
     PKG_BASH=''${PKG_BASH%/bin/bash}
-    PKG_COREUTILS=$(find ${buildRootDirectory}/nix/store -path '*/bin/env' | sed 's,^${buildRootDirectory},,')
-    PKG_COREUTILS=''${PKG_COREUTILS%/bin/env}
     PKG_NIX=$(find ${buildRootDirectory}/nix/store -path '*/bin/nix' | sed 's,^${buildRootDirectory},,')
     PKG_NIX=''${PKG_NIX%/bin/nix}
 
@@ -53,7 +51,6 @@ stdenv.mkDerivation {
     {
       bash = "$PKG_BASH";
       cacert = "$CACERT";
-      coreutils = "$PKG_COREUTILS";
       nix = "$PKG_NIX";
     }
     EOF

--- a/pkgs/nix-directory.nix
+++ b/pkgs/nix-directory.nix
@@ -23,8 +23,8 @@ stdenv.mkDerivation {
   name = "nix-directory";
 
   src = builtins.fetchurl {
-    url = "https://nixos.org/releases/nix/nix-2.8.1/nix-2.8.1-${config.build.arch}-linux.tar.xz";
-    sha256 = "0yqwvm95yxqqqckfln9wx1xpjsal655f7s6bw21s40cnkvxcqdyq";
+    url = "https://nixos.org/releases/nix/nix-2.11.0/nix-2.11.0-${config.build.arch}-linux.tar.xz";
+    sha256 = "179jjf9hy1860d7bsravykg15jqxdfm51fy14aihkjbc1q6knyyx";
   };
 
   PROOT_NO_SECCOMP = 1;  # see https://github.com/proot-me/PRoot/issues/106


### PR DESCRIPTION
This PR bumps the bootstrap Nix version to 2.11.0. This brings in a newer version of glibc which fixes issues with devices with BTI functionality. Since newer Nix bootstrap tarballs no longer include coreutils, let's also remove our dependency on it.

Tested on the Exynos variant of Galaxy S22 (SM-S901B). Fixes #199.