### PR TITLE
modules/build/activation: Prepend to PATH instead of setting it outright

### DIFF
--- a/modules/build/activation.nix
+++ b/modules/build/activation.nix
@@ -35,7 +35,7 @@ let
     set -eu
     set -o pipefail
 
-    export PATH="${activationBinPaths}"
+    export PATH="${activationBinPaths}:''${PATH:+:''${PATH}}"
     _NOD_GENERATION_DIR="$(realpath "$(dirname "$0")")"
     cd "$HOME"
 


### PR DESCRIPTION
Prior to this change: If your nix.conf has `max-jobs = 0` and `builders = ssh://...`, thus configuring it to do all build jobs remotely, activation would fail due to `nix-env` being unable to find `ssh` in `PATH`. By prepending to `PATH` instead of overriding it entirely, this is avoided.

Of course, `nix-env` probably shouldn't need a remote builder in order to simply upgrade to an already-built derivation, but that's a Nix issue if anything.