### PR TITLE
environment.nix: fix NIX_PATH environment variable

### DIFF
--- a/modules/environment/nix.nix
+++ b/modules/environment/nix.nix
@@ -166,7 +166,7 @@ in
     }
 
     (mkIf (cfg.nixPath != []) {
-      environment.sessionVariables.NIX_PATH = cfg.nixPath;
+      environment.sessionVariables.NIX_PATH = concatStringsSep ":" cfg.nixPath;
     })
   ];
 


### PR DESCRIPTION
Fixes https://github.com/t184256/nix-on-droid/issues/190