### PR TITLE
home-manager: fix directory not found error

### DIFF
--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -127,8 +127,7 @@ in
     # https://github.com/nix-community/home-manager/blob/0006da1381b87844c944fe8b925ec864ccf19348/modules/home-environment.nix#L414
     # Fortunately, it's not that hard to us to workaround with just a symlink.
     environment.etc = mkIf cfg.useUserPackages {
-      "profiles/per-user/${config.user.userName}".source =
-        /. + "${config.user.home}/.nix-profile";
+      "profiles/per-user/${config.user.userName}".source = "${config.user.home}/.nix-profile";
     };
 
   };


### PR DESCRIPTION
Prepend of /. produces directory not found error when building on a non nix-on-droid environment. The etc module works also with just a string.