### PR TITLE
Add nix-formatter-pack

### DIFF
--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
   push:
 jobs:
-  cachix:
+  lint:
     runs-on: ubuntu-latest
 
     steps:
@@ -13,8 +13,5 @@ jobs:
       - name: Install nix
         uses: cachix/install-nix-action@v18
 
-      - name: Run formatter
-        run: nix fmt -- --check .
-
-      - name: Run statix
-        run: nix run nixpkgs#statix -- check
+      - name: Run nix-formatter-pack-check
+        run: nix build .#checks.x86_64-linux.nix-formatter-pack-check

--- a/flake.lock
+++ b/flake.lock
@@ -21,6 +21,28 @@
         "type": "github"
       }
     },
+    "nix-formatter-pack": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "nmd": "nmd",
+        "nmt": "nmt"
+      },
+      "locked": {
+        "lastModified": 1666720474,
+        "narHash": "sha256-iWojjDS1D19zpeZXbBdjWb9MiKmVVFQCqtJmtTXgPx8=",
+        "owner": "Gerschtli",
+        "repo": "nix-formatter-pack",
+        "rev": "14876cc8fe94a3d329964ecb073b4c988c7b61f5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Gerschtli",
+        "repo": "nix-formatter-pack",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1664019863,
@@ -52,9 +74,42 @@
         "type": "github"
       }
     },
+    "nmd": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1666190571,
+        "narHash": "sha256-Z1hc7M9X6L+H83o9vOprijpzhTfOBjd0KmUTnpHAVjA=",
+        "owner": "rycee",
+        "repo": "nmd",
+        "rev": "b75d312b4f33bd3294cd8ae5c2ca8c6da2afc169",
+        "type": "gitlab"
+      },
+      "original": {
+        "owner": "rycee",
+        "repo": "nmd",
+        "type": "gitlab"
+      }
+    },
+    "nmt": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1648075362,
+        "narHash": "sha256-u36WgzoA84dMVsGXzml4wZ5ckGgfnvS0ryzo/3zn/Pc=",
+        "owner": "rycee",
+        "repo": "nmt",
+        "rev": "d83601002c99b78c89ea80e5e6ba21addcfe12ae",
+        "type": "gitlab"
+      },
+      "original": {
+        "owner": "rycee",
+        "repo": "nmt",
+        "type": "gitlab"
+      }
+    },
     "root": {
       "inputs": {
         "home-manager": "home-manager",
+        "nix-formatter-pack": "nix-formatter-pack",
         "nixpkgs": "nixpkgs",
         "nixpkgs-for-bootstrap": "nixpkgs-for-bootstrap"
       }

--- a/modules/environment/nix.nix
+++ b/modules/environment/nix.nix
@@ -149,7 +149,7 @@ in
 
         "nix/registry.json".text = builtins.toJSON {
           version = 2;
-          flakes = mapAttrsToList (n: v: { inherit (v) from to exact; }) cfg.registry;
+          flakes = mapAttrsToList (_n: v: { inherit (v) from to exact; }) cfg.registry;
         };
       };
 

--- a/modules/nixpkgs/config.nix
+++ b/modules/nixpkgs/config.nix
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2021, see AUTHORS. Licensed under MIT License, see LICENSE.
+# Copyright (c) 2019-2022, see AUTHORS. Licensed under MIT License, see LICENSE.
 
 # Inspired by
 # https://github.com/rycee/home-manager/blob/master/modules/misc/nixpkgs.nix
@@ -15,7 +15,7 @@ with lib;
   config = {
 
     _module.args.pkgs = import <nixpkgs> (
-      filterAttrs (n: v: v != null) config.nixpkgs
+      filterAttrs (_n: v: v != null) config.nixpkgs
     );
 
     nixpkgs.overlays = import ../../overlays;

--- a/modules/nixpkgs/options.nix
+++ b/modules/nixpkgs/options.nix
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2021, see AUTHORS. Licensed under MIT License, see LICENSE.
+# Copyright (c) 2019-2022, see AUTHORS. Licensed under MIT License, see LICENSE.
 
 # Inspired by
 # https://github.com/rycee/home-manager/blob/master/modules/misc/nixpkgs.nix
@@ -46,7 +46,7 @@ let
           else lib.traceSeqN 1 x false;
       in
       traceXIfNot isConfig;
-    merge = args: fold (def: mergeConfig def.value) { };
+    merge = _args: fold (def: mergeConfig def.value) { };
   };
 
   overlayType = mkOptionType {

--- a/modules/time.nix
+++ b/modules/time.nix
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2020, see AUTHORS. Licensed under MIT License, see LICENSE.
+# Copyright (c) 2019-2022, see AUTHORS. Licensed under MIT License, see LICENSE.
 
 # Inspired by
 # https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/config/locale.nix
@@ -10,8 +10,6 @@
 with lib;
 
 let
-  cfg = config.time;
-
   tzdir = "${pkgs.tzdata}/share/zoneinfo";
   nospace = str: filter (c: c == " ") (stringToCharacters str) == [ ];
   timezoneType = types.nullOr (types.addCheck types.str nospace)

--- a/overlays/typespeed.nix
+++ b/overlays/typespeed.nix
@@ -1,13 +1,13 @@
-# Copyright (c) 2019-2020, see AUTHORS. Licensed under MIT License, see LICENSE.
+# Copyright (c) 2019-2022, see AUTHORS. Licensed under MIT License, see LICENSE.
 
-self: super:
+_self: super:
 
 let
   nixpkgs = import ./lib/nixpkgs.nix { inherit super; };
 in
 
 {
-  typespeed = nixpkgs.typespeed.overrideAttrs (old: {
+  typespeed = nixpkgs.typespeed.overrideAttrs (_old: {
     patches = nixpkgs.typespeed.patches ++ [
       ./typespeed-no-drop-priv.patch
     ];


### PR DESCRIPTION
I build a nice little tool to easily setup multiple formatters (we currently use nixpkgs-fmt and statix, this adds [deadnix](https://github.com/astro/deadnix)). The benefit is that running `nix fmt` fixes all issues found by all tools and `nix flake check` checks for all tools.

This is very opinionated so feel free to close it, if you don't like it :)

Requires https://github.com/t184256/nix-on-droid/pull/204.