### PR TITLE
Improvements for flake usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 * In an effort to reduce the number of arguments to `lib.nixOnDroidConfiguration`
   function in flake configurations, `system` is now inferred from `pkgs.system`
   and `config` and `extraModules` are now combined into `modules`
+* Add option `environment.motd` to edit the startup message that is printed in
+  every shell
 
 ## Release 22.05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
 * Fix usage of `extraSpecialArgs`: All values were previously set in
   `_module.args` instead of passing them as `specialArgs` into `evalModules`.
   This enables usage of `specialArgs` to use in `imports` in module defintions.
+* In an effort to reduce the number of arguments to `lib.nixOnDroidConfiguration`
+  function in flake configurations, `system` is now inferred from `pkgs.system`
+  and `config` and `extraModules` are now combined into `modules`
 
 ## Release 22.05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 * Add support for `nix profile` managed profiles
 * Add possibilty to bootstrap Nix-on-Droid with flakes via prompt on initial
   boot
+* Fix usage of `extraSpecialArgs`: All values were previously set in
+  `_module.args` instead of passing them as `specialArgs` into `evalModules`.
+  This enables usage of `specialArgs` to use in `imports` in module defintions.
 
 ## Release 22.05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@
   and `config` and `extraModules` are now combined into `modules`
 * Add option `environment.motd` to edit the startup message that is printed in
   every shell
+* For flake setups, the output `nixOnDroidConfigurations.default` will be used
+  when `nix-on-droid switch --flake path/to/flake` is called without attribute
+  name
 
 ## Release 22.05
 

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ A minimal example could look like the following:
 
   outputs = { self, nixpkgs, nix-on-droid }: {
 
-    nixOnDroidConfigurations.deviceName = nix-on-droid.lib.nixOnDroidConfiguration {
+    nixOnDroidConfigurations.default = nix-on-droid.lib.nixOnDroidConfiguration {
       modules = [ ./nix-on-droid.nix ];
     };
 
@@ -208,8 +208,9 @@ nix flake init --template github:t184256/nix-on-droid#advanced
 
 ### Usage with `nix-on-droid`
 
-Use `nix-on-droid switch --flake .#device` to build and activate your configuration (`.#device` will expand to
-`.#nixOnDroidConfigurations.device`).
+Use `nix-on-droid switch --flake path/to/flake#device` to build and activate your configuration (`path/to/flake#device`
+will expand to `.#nixOnDroidConfigurations.device`). If you run `nix-on-droid switch --flake path/to/flake`, the
+`default` configuration will be used.
 
 **Note:** Currently, nix-on-droid can not be built with an pure flake build because of hardcoded store paths for proot.
 Therefore, every evaluation of a flake configuration will be executed with `--impure` flag. (This behaviour will be

--- a/README.md
+++ b/README.md
@@ -193,8 +193,7 @@ A minimal example could look like the following:
   outputs = { self, nixpkgs, nix-on-droid }: {
 
     nixOnDroidConfigurations.deviceName = nix-on-droid.lib.nixOnDroidConfiguration {
-      system = "aarch64-linux";
-      config = ./nix-on-droid.nix;
+      modules = [ ./nix-on-droid.nix ];
     };
 
   };

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2020, see AUTHORS. Licensed under MIT License, see LICENSE.
+# Copyright (c) 2019-2022, see AUTHORS. Licensed under MIT License, see LICENSE.
 
 { config ? null
 , extraModules ? [ ]
@@ -18,20 +18,11 @@ let
     else if builtins.pathExists defaultConfigFile then defaultConfigFile
     else pkgs.config.nix-on-droid or (throw "No config file found! Create one in ~/.config/nixpkgs/nix-on-droid.nix");
 
+  nodModules = import ./module-list.nix { inherit pkgs home-manager-path isFlake; };
+
   rawModule = evalModules {
-    modules = [
-      {
-        _module.args =
-          {
-            inherit home-manager-path isFlake;
-            pkgs = mkDefault pkgs;
-          }
-          // extraSpecialArgs;
-      }
-      configModule
-    ]
-    ++ extraModules
-    ++ import ./module-list.nix { inherit pkgs isFlake; };
+    modules = [ configModule ] ++ extraModules ++ nodModules;
+    specialArgs = extraSpecialArgs;
   };
 
   failedAssertions = map (x: x.message) (filter (x: !x.assertion) rawModule.config.assertions);

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -1,7 +1,6 @@
 # Copyright (c) 2019-2022, see AUTHORS. Licensed under MIT License, see LICENSE.
 
 { config ? null
-, extraModules ? [ ]
 , extraSpecialArgs ? { }
 , pkgs ? import <nixpkgs> { }
 , home-manager-path ? <home-manager>
@@ -21,7 +20,7 @@ let
   nodModules = import ./module-list.nix { inherit pkgs home-manager-path isFlake; };
 
   rawModule = evalModules {
-    modules = [ configModule ] ++ extraModules ++ nodModules;
+    modules = [ configModule ] ++ nodModules;
     specialArgs = extraSpecialArgs;
   };
 

--- a/modules/environment/login/login-inner.nix
+++ b/modules/environment/login/login-inner.nix
@@ -13,10 +13,11 @@ writeText "login-inner" ''
 
   set -eo pipefail
 
-  if [ "$#" -eq 0 ]; then  # if script is called from within nix-on-droid app
-    echo "Welcome to Nix-on-Droid!"
-    echo "If nothing works, open an issue at https://github.com/t184256/nix-on-droid/issues or try the rescue shell."
-  fi
+  ${lib.optionalString (config.environment.motd != null) ''
+    if [ "$#" -eq 0 ]; then  # if script is called from within nix-on-droid app
+      echo "${lib.removeSuffix "\n" config.environment.motd}"
+    fi
+  ''}
 
   ${lib.optionalString config.build.initialBuild ''
     if [ -e /etc/UNINTIALISED ]; then

--- a/modules/environment/login/login-inner.nix
+++ b/modules/environment/login/login-inner.nix
@@ -89,7 +89,7 @@ writeText "login-inner" ''
         ''}
 
         echo "Installing first nix-on-droid generation..."
-        ${nixCmd} run ${config.build.flake.nix-on-droid} -- switch --flake ${config.user.home}/.config/nix-on-droid#deviceName
+        ${nixCmd} run ${config.build.flake.nix-on-droid} -- switch --flake ${config.user.home}/.config/nix-on-droid
 
         . "${config.user.home}/.nix-profile/etc/profile.d/nix-on-droid-session-init.sh"
 

--- a/modules/environment/session-init.nix
+++ b/modules/environment/session-init.nix
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2020, see AUTHORS. Licensed under MIT License, see LICENSE.
+# Copyright (c) 2019-2022, see AUTHORS. Licensed under MIT License, see LICENSE.
 
 { config, lib, pkgs, ... }:
 
@@ -49,41 +49,54 @@ in
 
   options = {
 
-    environment.sessionVariables = mkOption {
-      default = { };
-      type = types.attrs;
-      example = { EDITOR = "emacs"; GS_OPTIONS = "-sPAPERSIZE=a4"; };
-      description = ''
-        Environment variables to always set at login.
-        </para><para>
-        The values may refer to other environment variables using
-        POSIX.2 style variable references. For example, a variable
-        <varname>parameter</varname> may be referenced as
-        <code>$parameter</code> or <code>''${parameter}</code>. A
-        default value <literal>foo</literal> may be given as per
-        <code>''${parameter:-foo}</code> and, similarly, an alternate
-        value <literal>bar</literal> can be given as per
-        <code>''${parameter:+bar}</code>.
-        </para><para>
-        Note, these variables may be set in any order so no session
-        variable may have a runtime dependency on another session
-        variable. In particular code like
-        <programlisting language="nix">
-        environment.sessionVariables = {
-          FOO = "Hello";
-          BAR = "$FOO World!";
-        };
-        </programlisting>
-        may not work as expected. If you need to reference another
-        session variable, then do so inside Nix instead. The above
-        example then becomes
-        <programlisting language="nix">
-        environment.sessionVariables = {
-          FOO = "Hello";
-          BAR = "''${config.environment.sessionVariables.FOO} World!";
-        };
-        </programlisting>
-      '';
+    environment = {
+      motd = mkOption {
+        default = ''
+          Welcome to Nix-on-Droid!
+          If nothing works, open an issue at https://github.com/t184256/nix-on-droid/issues or try the rescue shell.
+        '';
+        type = types.nullOr types.lines;
+        description = ''
+          Text to show on every new shell created by nix-on-droid.
+        '';
+      };
+
+      sessionVariables = mkOption {
+        default = { };
+        type = types.attrs;
+        example = { EDITOR = "emacs"; GS_OPTIONS = "-sPAPERSIZE=a4"; };
+        description = ''
+          Environment variables to always set at login.
+          </para><para>
+          The values may refer to other environment variables using
+          POSIX.2 style variable references. For example, a variable
+          <varname>parameter</varname> may be referenced as
+          <code>$parameter</code> or <code>''${parameter}</code>. A
+          default value <literal>foo</literal> may be given as per
+          <code>''${parameter:-foo}</code> and, similarly, an alternate
+          value <literal>bar</literal> can be given as per
+          <code>''${parameter:+bar}</code>.
+          </para><para>
+          Note, these variables may be set in any order so no session
+          variable may have a runtime dependency on another session
+          variable. In particular code like
+          <programlisting language="nix">
+          environment.sessionVariables = {
+            FOO = "Hello";
+            BAR = "$FOO World!";
+          };
+          </programlisting>
+          may not work as expected. If you need to reference another
+          session variable, then do so inside Nix instead. The above
+          example then becomes
+          <programlisting language="nix">
+          environment.sessionVariables = {
+            FOO = "Hello";
+            BAR = "''${config.environment.sessionVariables.FOO} World!";
+          };
+          </programlisting>
+        '';
+      };
     };
 
   };

--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -1,6 +1,6 @@
-# Copyright (c) 2019-2021, see AUTHORS. Licensed under MIT License, see LICENSE.
+# Copyright (c) 2019-2022, see AUTHORS. Licensed under MIT License, see LICENSE.
 
-{ pkgs, isFlake }:
+{ pkgs, home-manager-path, isFlake }:
 
 [
   ./build/activation.nix
@@ -22,4 +22,12 @@
   ./user.nix
   ./version.nix
   (pkgs.path + "/nixos/modules/misc/assertions.nix")
+
+  {
+    _file = ./module-list.nix;
+    _module.args = {
+      inherit home-manager-path isFlake;
+      pkgs = pkgs.lib.mkDefault pkgs;
+    };
+  }
 ] ++ pkgs.lib.optionals (!isFlake) [ ./nixpkgs/config.nix ]

--- a/nix-on-droid/nix-on-droid.sh
+++ b/nix-on-droid/nix-on-droid.sh
@@ -58,7 +58,8 @@ function doHelp() {
     echo "  -n|--dry-run      Do a dry run, only prints what actions would be taken"
     echo "  -v|--verbose      Verbose output"
     echo "  -f|--file FILE    Path to config file"
-    echo "  -F|--flake FLAKE  Path to flake and device name (e.g. path/to/flake#device)"
+    echo "  -F|--flake FLAKE  Path to flake and device name (e.g. path/to/flake#device),"
+    echo "                    device 'default' will be used if no attribute name is given"
     echo
     echo "Options passed on to nix build"
     echo
@@ -139,7 +140,12 @@ while [[ $# -gt 0 ]]; do
             PASSTHROUGH_OPTS+=(--extra-experimental-features "flakes nix-command")
             # add "nixOnDroidConfigurations." as prefix in attribute name, e.g.
             # /path/to/flake#device -> /path/to/flake#nixOnDroidConfigurations.device
-            FLAKE_CONFIG_URI="${1%#*}#nixOnDroidConfigurations.${1#*#}"
+            # if no attribute name given, use "default"
+            if [[ "$1" =~ \# ]]; then
+                FLAKE_CONFIG_URI="${1%#*}#nixOnDroidConfigurations.${1#*#}"
+            else
+                FLAKE_CONFIG_URI="${1}#nixOnDroidConfigurations.default"
+            fi
             shift
             ;;
         -h|--help)

--- a/nix-on-droid/nix-on-droid.sh
+++ b/nix-on-droid/nix-on-droid.sh
@@ -90,7 +90,14 @@ function doHelp() {
 
 function doOnDeviceTest() {
     # This is for maintainer convenience only, see tests/on-device/.run.sh
-    nix-channel --update nix-on-droid
+
+    # /n-o-d/unpacked is available in fakedroid environment
+    if [[ -d "/n-o-d/unpacked" ]]; then
+        export NIX_PATH="nix-on-droid=/n-o-d/unpacked:$NIX_PATH"
+    else
+        nix-channel --update nix-on-droid
+    fi
+
     exec "$(nix-instantiate --eval --expr \
                             "<nix-on-droid/tests/on-device/.run.sh>")"
 }

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -25,15 +25,16 @@ let
   modules = import ../modules {
     inherit pkgs;
 
-    extraModules = [ ../modules/build/initial-build.nix ];
-    extraSpecialArgs = {
-      inherit initialPackageInfo;
-      pkgs = pkgs.lib.mkForce pkgs; # to override ./modules/nixpkgs/config.nix
-    };
-
     isFlake = true;
 
     config = {
+      imports = [ ../modules/build/initial-build.nix ];
+
+      _module.args = {
+        inherit initialPackageInfo;
+        pkgs = pkgs.lib.mkForce pkgs; # to override ./modules/nixpkgs/config.nix
+      };
+
       # Fix invoking bash after initial build.
       user.shell = "${initialPackageInfo.bash}/bin/bash";
 

--- a/templates/advanced/flake.nix
+++ b/templates/advanced/flake.nix
@@ -19,11 +19,10 @@
   outputs = { self, nixpkgs, home-manager, nix-on-droid }: {
 
     nixOnDroidConfigurations.deviceName = nix-on-droid.lib.nixOnDroidConfiguration {
-      system = "aarch64-linux";
-      config = ./nix-on-droid.nix;
+      modules = [
+        ./nix-on-droid.nix
 
-      # list of extra modules for nix-on-droid system
-      extraModules = [
+        # list of extra modules for nix-on-droid system
         # { nix.registry.nixpkgs.flake = nixpkgs; }
         # ./path/to/module.nix
 

--- a/templates/advanced/flake.nix
+++ b/templates/advanced/flake.nix
@@ -18,7 +18,7 @@
 
   outputs = { self, nixpkgs, home-manager, nix-on-droid }: {
 
-    nixOnDroidConfigurations.deviceName = nix-on-droid.lib.nixOnDroidConfiguration {
+    nixOnDroidConfigurations.default = nix-on-droid.lib.nixOnDroidConfiguration {
       modules = [
         ./nix-on-droid.nix
 

--- a/templates/home-manager/flake.nix
+++ b/templates/home-manager/flake.nix
@@ -19,8 +19,7 @@
   outputs = { self, nixpkgs, home-manager, nix-on-droid }: {
 
     nixOnDroidConfigurations.deviceName = nix-on-droid.lib.nixOnDroidConfiguration {
-      system = "aarch64-linux";
-      config = ./nix-on-droid.nix;
+      modules = [ ./nix-on-droid.nix ];
     };
 
   };

--- a/templates/home-manager/flake.nix
+++ b/templates/home-manager/flake.nix
@@ -18,7 +18,7 @@
 
   outputs = { self, nixpkgs, home-manager, nix-on-droid }: {
 
-    nixOnDroidConfigurations.deviceName = nix-on-droid.lib.nixOnDroidConfiguration {
+    nixOnDroidConfigurations.default = nix-on-droid.lib.nixOnDroidConfiguration {
       modules = [ ./nix-on-droid.nix ];
     };
 

--- a/templates/minimal/flake.nix
+++ b/templates/minimal/flake.nix
@@ -12,7 +12,7 @@
 
   outputs = { self, nixpkgs, nix-on-droid }: {
 
-    nixOnDroidConfigurations.deviceName = nix-on-droid.lib.nixOnDroidConfiguration {
+    nixOnDroidConfigurations.default = nix-on-droid.lib.nixOnDroidConfiguration {
       modules = [ ./nix-on-droid.nix ];
     };
 

--- a/templates/minimal/flake.nix
+++ b/templates/minimal/flake.nix
@@ -13,8 +13,7 @@
   outputs = { self, nixpkgs, nix-on-droid }: {
 
     nixOnDroidConfigurations.deviceName = nix-on-droid.lib.nixOnDroidConfiguration {
-      system = "aarch64-linux";
-      config = ./nix-on-droid.nix;
+      modules = [ ./nix-on-droid.nix ];
     };
 
   };

--- a/tests/on-device/config-flake-default.nix
+++ b/tests/on-device/config-flake-default.nix
@@ -1,0 +1,17 @@
+{
+  description = "nix-on-droid configuration";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/release-22.05";
+    nix-on-droid.url = "<<FLAKE_URL>>";
+    nix-on-droid.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs = { nix-on-droid, ... }: {
+    nixOnDroidConfigurations = {
+      default = nix-on-droid.lib.nixOnDroidConfiguration {
+        modules = [ ./nix-on-droid.nix ];
+      };
+    };
+  };
+}

--- a/tests/on-device/config-flake-h-m.flake.nix
+++ b/tests/on-device/config-flake-h-m.flake.nix
@@ -12,8 +12,7 @@
   outputs = { nix-on-droid, ... }: {
     nixOnDroidConfigurations = {
       device = nix-on-droid.lib.nixOnDroidConfiguration {
-        config = ./nix-on-droid.nix;
-        system = "aarch64-linux";
+        modules = [ ./nix-on-droid.nix ];
       };
     };
   };

--- a/tests/on-device/config-flake.bats
+++ b/tests/on-device/config-flake.bats
@@ -1,8 +1,11 @@
-# Copyright (c) 2019-2021, see AUTHORS. Licensed under MIT License, see LICENSE.
+# Copyright (c) 2019-2022, see AUTHORS. Licensed under MIT License, see LICENSE.
 
 load lib
 
-@test 'flake example works' {
+function flake_example() {
+  local flake_url="$1"
+  local flake_file_name="$2"
+
   # assertions to verify initial state is as expected
   assert_command vi
   assert_no_command unzip
@@ -15,10 +18,10 @@ load lib
     > ~/.config/nixpkgs/nix-on-droid.nix
 
   _sed "s|<<FLAKE_URL>>|$FLAKE_URL|g" \
-    "$ON_DEVICE_TESTS_DIR/config-flake.nix" \
+    "$ON_DEVICE_TESTS_DIR/$flake_file_name" \
     > ~/.config/nixpkgs/flake.nix
 
-  nix-on-droid switch --flake ~/.config/nixpkgs#device
+  nix-on-droid switch --flake "$flake_url"
 
   # test presence of several crucial commands
   assert_command nix-on-droid nix-shell bash
@@ -31,4 +34,12 @@ load lib
   switch_to_default_config
   assert_command vi
   assert_no_command unzip
+}
+
+@test 'flake example works' {
+  flake_example ~/.config/nixpkgs#device config-flake.nix
+}
+
+@test 'flake with default config works' {
+  flake_example ~/.config/nixpkgs config-flake-default.nix
 }

--- a/tests/on-device/config-flake.nix
+++ b/tests/on-device/config-flake.nix
@@ -10,8 +10,7 @@
   outputs = { nix-on-droid, ... }: {
     nixOnDroidConfigurations = {
       device = nix-on-droid.lib.nixOnDroidConfiguration {
-        config = ./nix-on-droid.nix;
-        system = "aarch64-linux";
+        modules = [ ./nix-on-droid.nix ];
       };
     };
   };


### PR DESCRIPTION
This PR includes some things:

- fix usage of `extraSpecialArgs` (we did not set the values of this argument as special arg but as `_module.args` which disallows usage of these values in `imports` in config modules)
- remove parameters/simplify usage of `lib.nixOnDroidConfiguration` (inspired by https://github.com/nix-community/home-manager/pull/3037)
- add option for text on shell startup to allow changing or removing it
- add support for `default` config in `flake`, this is an easy convenience helper for people only using one device
- some improvements for fakedroid environment testing

If you want me to split some commits into separate PRs, I can do that, but this may result in some merge conflicts that I tried to avoid with this big PR :)

Sorry for the high load of PRs lately, got quite some motivation and time the last weeks :) If I can make the review process easier for you, I am happy to help.