### PR TITLE
ci: fix incorrect path to docs directory

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,7 +44,7 @@ jobs:
             --recursive \
             --dereference \
             --no-preserve=mode,ownership \
-            result/share/doc/nix-formatter-pack \
+            result/share/doc/nix-on-droid \
             public
 
       - name: Setup Pages


### PR DESCRIPTION
Copy-paste error, sorry.

BTW: You may need to enable gh pages in the repo settings. I am not 100% sure.