### PR TITLE
fix(terminal.nix): quote font paths

### DIFF
--- a/modules/terminal.nix
+++ b/modules/terminal.nix
@@ -44,24 +44,24 @@ in
       if (cfg.font != null) then
         {
           linkFont = ''
-            $DRY_RUN_CMD mkdir $VERBOSE_ARG -p ${configDir}
-            if [ -e ${fontTarget} ] && ! [ -L ${fontTarget} ]; then
-              $DRY_RUN_CMD mv $VERBOSE_ARG ${fontTarget} ${fontBackup}
+            $DRY_RUN_CMD mkdir $VERBOSE_ARG -p "${configDir}"
+            if [ -e "${fontTarget}" ] && ! [ -L "${fontTarget}" ]; then
+              $DRY_RUN_CMD mv $VERBOSE_ARG "${fontTarget}" "${fontBackup}"
               $DRY_RUN_CMD echo "${fontTarget} has been moved to ${fontBackup}"
             fi
-            $DRY_RUN_CMD ln $VERBOSE_ARG -sf ${fontPath} ${fontTarget}
+            $DRY_RUN_CMD ln $VERBOSE_ARG -sf "${fontPath}" "${fontTarget}"
           '';
         }
       else
         {
           unlinkFont = ''
-            if [ -e ${fontTarget} ] && [ -L ${fontTarget} ]; then
-              $DRY_RUN_CMD rm $VERBOSE_ARG ${fontTarget}
-              if [ -e ${fontBackup} ]; then
-                $DRY_RUN_CMD mv $VERBOSE_ARG ${fontBackup} ${fontTarget}
+            if [ -e "${fontTarget}" ] && [ -L "${fontTarget}" ]; then
+              $DRY_RUN_CMD rm $VERBOSE_ARG "${fontTarget}"
+              if [ -e "${fontBackup}" ]; then
+                $DRY_RUN_CMD mv $VERBOSE_ARG "${fontBackup}" "${fontTarget}"
                 $DRY_RUN_CMD echo "${fontTarget} has been restored from backup"
               else
-                if $DRY_RUN_CMD rm $VERBOSE_ARG -d ${configDir} 2>/dev/null
+                if $DRY_RUN_CMD rm $VERBOSE_ARG -d "${configDir}" 2>/dev/null
                 then
                   $DRY_RUN_CMD echo "removed empty ${configDir}"
                 fi


### PR DESCRIPTION
**Problem:**

Currently, if one wants to use a font, whose path contains spaces, for instance a nerdfont:

```nix
{
  terminal.font =
    let
      firacode = pkgs.nerdfonts.override {
        fonts = [ "FiraCode" ];
      };
      fontPath = "share/fonts/truetype/NerdFonts/Fira Code Regular Nerd Font Complete Mono.ttf";
    in
      "${firacode}/${fontPath}";
}
```

`nix-on-droid` would fail to create a correct symlink because the references to `${fontTarget}` aren't quoted which leads to `ln` treating the space-separated parts of the font name as different arguments.

Quoting `man ln`/`LN(1)`:

```
     Given more than two arguments, ln makes links in target_dir to all the named
     source files.  The links made will have the same name as the files being linked
     to.
```

which isn't the wanted behaviour here.

**Solution:**

Quote all unquoted references to nix variables in the `linkFont` script in `modules/terminal.nix`

**Demo:**

In a `nix-on-droid` configuration using my fork `github:reo101/nix-on-droid/reo101/font_path_quoting` the symbolink link is created correctly:

![image](https://user-images.githubusercontent.com/37866329/204039503-da1cc55e-c026-416a-908e-f00c7230c6ce.png)