### PR TITLE
22.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 ### New Options
 
 * Terminal font now should be specified using `terminal.font` option,
-  set it to a TTF file to apply a font.
+  set it to any file containing a font to apply it.
   An in-app `Styling` option will no longer work.
   Previously present file will be backed up to `~/.termux/font.ttf.bak`.
 * Add option `environment.motd` to edit the startup message that is printed in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@
   name
 * Add html and man pages with all available options, see <https://t184256.github.io/nix-on-droid/>
   and `nix build github:t184256/nix-on-droid#manPages`
+* The option `system.stateVersion` does not have a default value anymore.
+  Previously, its default was `"19.09"` the release the state version was
+  introduced.
 
 ## Release 22.05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,29 @@
 
 ## Release 22.11
 
+### Compatibility considerations
+
+* Fix usage of `extraSpecialArgs`: All values were previously set in
+  `_module.args` instead of passing them as `specialArgs` into `evalModules`.
+  This enables usage of `specialArgs` to use in `imports` in module defintions.
+* In an effort to reduce the number of arguments to `lib.nixOnDroidConfiguration`
+  function in flake configurations, `system` is now inferred from `pkgs.system`
+  and `config` and `extraModules` are now combined into `modules`
+* The option `system.stateVersion` does not have a default value anymore.
+  Previously, its default was `"19.09"` the release the state version was
+  introduced.
+
+### New Options
+
 * Terminal font now should be specified using `terminal.font` option,
   set it to a TTF file to apply a font.
   An in-app `Styling` option will no longer work.
   Previously present file will be backed up to `~/.termux/font.ttf.bak`.
+* Add option `environment.motd` to edit the startup message that is printed in
+  every shell
+
+### Other notable changes
+
 * `/proc/uptime` is now faked with a stub that allows unpatched `ps` to work.
 * Refactored project for flakes usage (still supporting non-flake setups on
   device, but bootstrap zip ball creation and running tests via fakedroid
@@ -15,22 +34,11 @@
 * Add support for `nix profile` managed profiles
 * Add possibilty to bootstrap Nix-on-Droid with flakes via prompt on initial
   boot
-* Fix usage of `extraSpecialArgs`: All values were previously set in
-  `_module.args` instead of passing them as `specialArgs` into `evalModules`.
-  This enables usage of `specialArgs` to use in `imports` in module defintions.
-* In an effort to reduce the number of arguments to `lib.nixOnDroidConfiguration`
-  function in flake configurations, `system` is now inferred from `pkgs.system`
-  and `config` and `extraModules` are now combined into `modules`
-* Add option `environment.motd` to edit the startup message that is printed in
-  every shell
 * For flake setups, the output `nixOnDroidConfigurations.default` will be used
   when `nix-on-droid switch --flake path/to/flake` is called without attribute
   name
 * Add html and man pages with all available options, see <https://t184256.github.io/nix-on-droid/>
   and `nix build github:t184256/nix-on-droid#manPages`
-* The option `system.stateVersion` does not have a default value anymore.
-  Previously, its default was `"19.09"` the release the state version was
-  introduced.
 
 ## Release 22.05
 
@@ -46,7 +54,7 @@
 
 * The `nix.package` can be used to set the system-wide nix package.
 
-## Removed Options
+### Removed Options
 
 * The `system.workaround.make-posix-spawn.enable` has been removed.
 * i686 support has been removed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## Release 22.11 (unreleased)
+## Release 23.05 (unreleased)
+
+## Release 22.11
 
 * Terminal font now should be specified using `terminal.font` option,
   set it to a TTF file to apply a font.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ for example:
 
 {
   environment.packages = [ pkgs.vim ];
-  system.stateVersion = "22.05";
+  system.stateVersion = "22.11";
 }
 ```
 
@@ -67,7 +67,7 @@ An alternative location is `~/.config/nixpkgs/config.nix` with the key
 
     {
       environment.packages = [ pkgs.vim ];
-      system.stateVersion = "22.05";
+      system.stateVersion = "22.11";
     };
 }
 ```
@@ -80,7 +80,7 @@ To enable `home-manager` you simply need to follow the instructions already prov
 
 1.  Add `home-manager` channel:
     ```sh
-    nix-channel --add https://github.com/rycee/home-manager/archive/release-22.05.tar.gz home-manager
+    nix-channel --add https://github.com/rycee/home-manager/archive/release-22.11.tar.gz home-manager
     nix-channel --update
     ```
 2.  Configure `home-manager`:
@@ -89,7 +89,7 @@ To enable `home-manager` you simply need to follow the instructions already prov
 
     {
       # Read Nix-on-Droid changelog before changing this value
-      system.stateVersion = "22.05";
+      system.stateVersion = "22.11";
 
       # insert Nix-on-Droid config
 
@@ -97,7 +97,7 @@ To enable `home-manager` you simply need to follow the instructions already prov
         { pkgs, ... }:
         {
           # Read home-manager changelog before changing this value
-          home.stateVersion = "22.05";
+          home.stateVersion = "22.11";
 
           # insert home-manager config
         };
@@ -181,10 +181,10 @@ A minimal example could look like the following:
   description = "Minimal example of Nix-on-Droid system config.";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.11";
 
     nix-on-droid = {
-      url = "github:t184256/nix-on-droid/release-22.05";
+      url = "github:t184256/nix-on-droid/release-22.11";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };

--- a/docs/manual.xml
+++ b/docs/manual.xml
@@ -31,10 +31,10 @@
 <programlisting language="nix">
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.11";
 
     nix-on-droid = {
-      url = "github:t184256/nix-on-droid/release-22.05";
+      url = "github:t184256/nix-on-droid/release-22.11";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };

--- a/flake.lock
+++ b/flake.lock
@@ -60,17 +60,17 @@
     },
     "nixpkgs-for-bootstrap": {
       "locked": {
-        "lastModified": 1656265786,
-        "narHash": "sha256-A9RkoGrxzsmMm0vily18p92Rasb+MbdDMaSnzmywXKw=",
+        "lastModified": 1669834992,
+        "narHash": "sha256-YnhZGHgb4C3Q7DSGisO/stc50jFb9F/MzHeKS4giotg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cd90e773eae83ba7733d2377b6cdf84d45558780",
+        "rev": "596a8e828c5dfa504f91918d0fa4152db3ab5502",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cd90e773eae83ba7733d2377b6cdf84d45558780",
+        "rev": "596a8e828c5dfa504f91918d0fa4152db3ab5502",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -5,9 +5,9 @@
     nixpkgs.url = "github:NixOS/nixpkgs";
 
     # for bootstrap zip ball creation and proot-termux builds, we use a fixed version of nixpkgs to ease maintanence.
-    # head of nixos-22.05 as of 2022-06-27
+    # head of nixos-22.11 as of 2022-12-01
     # note: when updating nixpkgs-for-bootstrap, update store paths of proot-termux in modules/environment/login/default.nix
-    nixpkgs-for-bootstrap.url = "github:NixOS/nixpkgs/cd90e773eae83ba7733d2377b6cdf84d45558780";
+    nixpkgs-for-bootstrap.url = "github:NixOS/nixpkgs/596a8e828c5dfa504f91918d0fa4152db3ab5502";
 
     home-manager = {
       url = "github:nix-community/home-manager";

--- a/modules/build/initial-build.nix
+++ b/modules/build/initial-build.nix
@@ -5,8 +5,8 @@
 with lib;
 
 let
-  defaultNixpkgsBranch = "nixos-22.05";
-  defaultNixOnDroidBranch = "release-22.05";
+  defaultNixpkgsBranch = "nixos-22.11";
+  defaultNixOnDroidBranch = "release-22.11";
 
   defaultNixpkgsChannel = "https://nixos.org/channels/${defaultNixpkgsBranch}";
   defaultNixOnDroidChannel = "https://github.com/t184256/nix-on-droid/archive/${defaultNixOnDroidBranch}.tar.gz";

--- a/modules/environment/login/default.nix
+++ b/modules/environment/login/default.nix
@@ -82,7 +82,7 @@ in
     environment.files = {
       inherit login loginInner;
 
-      prootStatic = "/nix/store/wsgnxpmrdmjy7qrsxvp7r5jandbabzjl-proot-termux-static-aarch64-unknown-linux-android-unstable-2022-05-03";
+      prootStatic = "/nix/store/8xg8jnaczivjjrd9nq38qvrp9z7avib1-proot-termux-static-aarch64-unknown-linux-android-unstable-2022-05-03";
     };
 
   };

--- a/modules/environment/login/nix-on-droid.nix.default
+++ b/modules/environment/login/nix-on-droid.nix.default
@@ -28,7 +28,7 @@
   environment.etcBackupExtension = ".bak";
 
   # Read the changelog before changing this value
-  system.stateVersion = "22.05";
+  system.stateVersion = "22.11";
 
   # Set up nix for flakes
   #nix.extraOptions = ''
@@ -39,7 +39,7 @@
   #time.timeZone = "Europe/Berlin";
 
   # After installing home-manager channel like
-  #   nix-channel --add https://github.com/rycee/home-manager/archive/release-22.05.tar.gz home-manager
+  #   nix-channel --add https://github.com/rycee/home-manager/archive/release-22.11.tar.gz home-manager
   #   nix-channel --update
   # you can configure home-manager in here like
   #home-manager = {
@@ -49,7 +49,7 @@
   #    { config, lib, pkgs, ... }:
   #    {
   #      # Read the changelog before changing this value
-  #      home.stateVersion = "22.05";
+  #      home.stateVersion = "22.11";
   #
   #      # insert home-manager config
   #    };

--- a/modules/terminal.nix
+++ b/modules/terminal.nix
@@ -20,7 +20,7 @@ in
       example = lib.literalExpression
         ''"''${pkgs.terminus_font_ttf}/share/fonts/truetype/TerminusTTF.ttf"'';
       description = ''
-        Font used for the terminal.  Must be a path to a TTF font.
+        Font used for the terminal.
       '';
     };
 

--- a/modules/version.nix
+++ b/modules/version.nix
@@ -12,7 +12,6 @@ with lib;
 
     system.stateVersion = mkOption {
       type = types.enum [ "19.09" "20.03" "20.09" "21.05" "21.11" "22.05" ];
-      default = "19.09";
       description = ''
         It is occasionally necessary for Nix-on-Droid to change
         configuration defaults in a way that is incompatible with

--- a/modules/version.nix
+++ b/modules/version.nix
@@ -11,7 +11,16 @@ with lib;
   options = {
 
     system.stateVersion = mkOption {
-      type = types.enum [ "19.09" "20.03" "20.09" "21.05" "21.11" "22.05" ];
+      type = types.enum [
+        "19.09"
+        "20.03"
+        "20.09"
+        "21.05"
+        "21.11"
+        "22.05"
+        "22.11"
+        "23.05"
+      ];
       description = ''
         It is occasionally necessary for Nix-on-Droid to change
         configuration defaults in a way that is incompatible with

--- a/nix-on-droid/default.nix
+++ b/nix-on-droid/default.nix
@@ -1,6 +1,6 @@
-# Copyright (c) 2019-2020, see AUTHORS. Licensed under MIT License, see LICENSE.
+# Copyright (c) 2019-2022, see AUTHORS. Licensed under MIT License, see LICENSE.
 
-{ bash, coreutils, lib, nix, nix_2_4, runCommand }:
+{ bash, coreutils, lib, nix, runCommand }:
 
 runCommand
   "nix-on-droid"
@@ -14,6 +14,5 @@ runCommand
     substituteInPlace $out/bin/nix-on-droid \
       --subst-var-by bash "${bash}" \
       --subst-var-by coreutils "${coreutils}" \
-      --subst-var-by nix "${nix}" \
-      --subst-var-by nixge24 "${if lib.versionAtLeast nix.version "2.4pre" then nix else nix_2_4}"
+      --subst-var-by nix "${nix}"
   ''

--- a/nix-on-droid/nix-on-droid.sh
+++ b/nix-on-droid/nix-on-droid.sh
@@ -28,15 +28,13 @@ function nixActivationPackage() {
     local extraArgs=("${@:2}"
                      --extra-experimental-features nix-command
                      "${PASSTHROUGH_OPTS[@]}")
-    local nix=nix
     if [[ -n "${FLAKE_CONFIG_URI}" ]]; then
-        nix=@nixge24@/bin/nix
         extraArgs+=(--impure "${FLAKE_CONFIG_URI}.activationPackage")
     else
         extraArgs+=(--file "<nix-on-droid/modules>" activationPackage)
     fi
 
-    $nix "${command}" "${extraArgs[@]}"
+    nix "${command}" "${extraArgs[@]}"
 }
 
 

--- a/overlays/lib/nixpkgs.nix
+++ b/overlays/lib/nixpkgs.nix
@@ -3,12 +3,12 @@
 { super }:
 
 let
-  # head of nixos-22.05 as of 2022-06-27
+  # head of nixos-22.11 as of 2022-12-01
   pinnedPkgsSrc = super.fetchFromGitHub {
     owner = "NixOS";
     repo = "nixpkgs";
-    rev = "cd90e773eae83ba7733d2377b6cdf84d45558780";
-    sha256 = "1b2wn1ncx9x4651vfcgyqrm93pd7ghnrgqjbkf6ckkpidah69m03";
+    rev = "596a8e828c5dfa504f91918d0fa4152db3ab5502";
+    sha256 = "sha256-YnhZGHgb4C3Q7DSGisO/stc50jFb9F/MzHeKS4giotg=";
   };
 in
 

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -35,6 +35,8 @@ let
         pkgs = pkgs.lib.mkForce pkgs; # to override ./modules/nixpkgs/config.nix
       };
 
+      system.stateVersion = "22.05";
+
       # Fix invoking bash after initial build.
       user.shell = "${initialPackageInfo.bash}/bin/bash";
 

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -35,7 +35,7 @@ let
         pkgs = pkgs.lib.mkForce pkgs; # to override ./modules/nixpkgs/config.nix
       };
 
-      system.stateVersion = "22.05";
+      system.stateVersion = "22.11";
 
       # Fix invoking bash after initial build.
       user.shell = "${initialPackageInfo.bash}/bin/bash";

--- a/pkgs/nix-directory.nix
+++ b/pkgs/nix-directory.nix
@@ -23,8 +23,8 @@ stdenv.mkDerivation {
   name = "nix-directory";
 
   src = builtins.fetchurl {
-    url = "https://nixos.org/releases/nix/nix-2.11.0/nix-2.11.0-${config.build.arch}-linux.tar.xz";
-    sha256 = "179jjf9hy1860d7bsravykg15jqxdfm51fy14aihkjbc1q6knyyx";
+    url = "https://nixos.org/releases/nix/nix-2.11.1/nix-2.11.1-${config.build.arch}-linux.tar.xz";
+    sha256 = "1cvdvka4qs1zx916g23pi9i024sx9h28nv8pvngxh3nk8gm8bvxq";
   };
 
   PROOT_NO_SECCOMP = 1; # see https://github.com/proot-me/PRoot/issues/106

--- a/pkgs/nix-directory.nix
+++ b/pkgs/nix-directory.nix
@@ -8,6 +8,7 @@ let
   prootCommand = lib.concatStringsSep " " [
     "${proot}/bin/proot"
     "-b ${pkgsStatic.nix}:/static-nix"
+    "-b /proc:/proc" # needed because tries to access /proc/self/exe
     "-r ${buildRootDirectory}"
     "-w /"
   ];
@@ -30,7 +31,8 @@ stdenv.mkDerivation {
   PROOT_NO_SECCOMP = 1; # see https://github.com/proot-me/PRoot/issues/106
 
   buildPhase = ''
-    mkdir --parents ${buildRootDirectory}/nix
+    # create nix state directory to satisfy nix heuristics to recognize the manual create /nix directory as valid nix store
+    mkdir --parents ${buildRootDirectory}/nix/var/nix/db
     cp --recursive store ${buildRootDirectory}/nix/store
 
     CACERT=$(find ${buildRootDirectory}/nix/store -path '*-nss-cacert-*/ca-bundle.crt' | sed 's,^${buildRootDirectory},,')

--- a/templates/advanced/flake.nix
+++ b/templates/advanced/flake.nix
@@ -2,15 +2,15 @@
   description = "Advanced example of Nix-on-Droid system config with home-manager.";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.11";
 
     home-manager = {
-      url = "github:nix-community/home-manager/release-22.05";
+      url = "github:nix-community/home-manager/release-22.11";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
     nix-on-droid = {
-      url = "github:t184256/nix-on-droid/release-22.05";
+      url = "github:t184256/nix-on-droid/release-22.11";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.home-manager.follows = "home-manager";
     };

--- a/templates/advanced/home.nix
+++ b/templates/advanced/home.nix
@@ -2,7 +2,7 @@
 
 {
   # Read the changelog before changing this value
-  home.stateVersion = "22.05";
+  home.stateVersion = "22.11";
 
   # insert home-manager config
 }

--- a/templates/advanced/nix-on-droid.nix
+++ b/templates/advanced/nix-on-droid.nix
@@ -28,7 +28,7 @@
   environment.etcBackupExtension = ".bak";
 
   # Read the changelog before changing this value
-  system.stateVersion = "22.05";
+  system.stateVersion = "22.11";
 
   # Set up nix for flakes
   nix.extraOptions = ''

--- a/templates/home-manager/flake.nix
+++ b/templates/home-manager/flake.nix
@@ -2,15 +2,15 @@
   description = "Minimal example of Nix-on-Droid system config with home-manager.";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.11";
 
     home-manager = {
-      url = "github:nix-community/home-manager/release-22.05";
+      url = "github:nix-community/home-manager/release-22.11";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
     nix-on-droid = {
-      url = "github:t184256/nix-on-droid/release-22.05";
+      url = "github:t184256/nix-on-droid/release-22.11";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.home-manager.follows = "home-manager";
     };

--- a/templates/home-manager/nix-on-droid.nix
+++ b/templates/home-manager/nix-on-droid.nix
@@ -28,7 +28,7 @@
   environment.etcBackupExtension = ".bak";
 
   # Read the changelog before changing this value
-  system.stateVersion = "22.05";
+  system.stateVersion = "22.11";
 
   # Set up nix for flakes
   nix.extraOptions = ''
@@ -47,7 +47,7 @@
       { config, lib, pkgs, ... }:
       {
         # Read the changelog before changing this value
-        home.stateVersion = "22.05";
+        home.stateVersion = "22.11";
 
         # insert home-manager config
       };

--- a/templates/minimal/flake.nix
+++ b/templates/minimal/flake.nix
@@ -2,10 +2,10 @@
   description = "Basic example of Nix-on-Droid system config.";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.11";
 
     nix-on-droid = {
-      url = "github:t184256/nix-on-droid/release-22.05";
+      url = "github:t184256/nix-on-droid/release-22.11";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };

--- a/templates/minimal/nix-on-droid.nix
+++ b/templates/minimal/nix-on-droid.nix
@@ -28,7 +28,7 @@
   environment.etcBackupExtension = ".bak";
 
   # Read the changelog before changing this value
-  system.stateVersion = "22.05";
+  system.stateVersion = "22.11";
 
   # Set up nix for flakes
   nix.extraOptions = ''

--- a/tests/fakedroid.sh
+++ b/tests/fakedroid.sh
@@ -22,7 +22,7 @@ REPO_DIR="$(git rev-parse --show-toplevel)"
 INJ_DIR="$REPO_DIR/.fakedroid/inj"
 ENV_DIR="$REPO_DIR/.fakedroid/env/$USE_FLAKE"
 
-QEMU_URL="https://github.com/multiarch/qemu-user-static/releases/download/v6.1.0-8/qemu-aarch64-static"
+QEMU_URL="https://github.com/multiarch/qemu-user-static/releases/download/v7.1.0-2/qemu-aarch64-static"
 QEMU="$INJ_DIR/qemu-aarch64"
 
 INSTALLATION_DIR="@installationDir@"

--- a/tests/on-device/config-flake-default.nix
+++ b/tests/on-device/config-flake-default.nix
@@ -2,7 +2,7 @@
   description = "Nix-on-Droid configuration";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/release-22.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/release-22.11";
     nix-on-droid.url = "<<FLAKE_URL>>";
     nix-on-droid.inputs.nixpkgs.follows = "nixpkgs";
   };

--- a/tests/on-device/config-flake-h-m.cfg.nix
+++ b/tests/on-device/config-flake-h-m.cfg.nix
@@ -1,7 +1,7 @@
 { pkgs, config, ... }:
 
 {
-  system.stateVersion = "22.05";
+  system.stateVersion = "22.11";
 
   # no nixpkgs.overlays defined
   environment.packages = with pkgs; [ zsh ];
@@ -9,7 +9,7 @@
   home-manager.config =
     { pkgs, ... }:
     {
-      home.stateVersion = "22.05";
+      home.stateVersion = "22.11";
 
       nixpkgs.overlays = config.nixpkgs.overlays;
       home.packages = with pkgs; [ dash ];

--- a/tests/on-device/config-flake-h-m.flake.nix
+++ b/tests/on-device/config-flake-h-m.flake.nix
@@ -2,8 +2,8 @@
   description = "Nix-on-Droid configuration";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/release-22.05";
-    home-manager.url = "github:nix-community/home-manager/release-22.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/release-22.11";
+    home-manager.url = "github:nix-community/home-manager/release-22.11";
     nix-on-droid.url = "<<FLAKE_URL>>";
     nix-on-droid.inputs.nixpkgs.follows = "nixpkgs";
     nix-on-droid.inputs.home-manager.follows = "home-manager";

--- a/tests/on-device/config-flake.nix
+++ b/tests/on-device/config-flake.nix
@@ -2,7 +2,7 @@
   description = "Nix-on-Droid configuration";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/release-22.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/release-22.11";
     nix-on-droid.url = "<<FLAKE_URL>>";
     nix-on-droid.inputs.nixpkgs.follows = "nixpkgs";
   };

--- a/tests/on-device/config-h-m.bats
+++ b/tests/on-device/config-h-m.bats
@@ -21,7 +21,7 @@ teardown() {
   [[ ! -e ~/.config/example ]]
 
   # set up / build / activate the configuration
-  nix-channel --add https://github.com/rycee/home-manager/archive/release-22.05.tar.gz home-manager
+  nix-channel --add https://github.com/rycee/home-manager/archive/release-22.11.tar.gz home-manager
   nix-channel --update
   cp "$ON_DEVICE_TESTS_DIR/config-h-m.nix" ~/.config/nixpkgs/nix-on-droid.nix
   nix-on-droid switch

--- a/tests/on-device/config-h-m.nix
+++ b/tests/on-device/config-h-m.nix
@@ -1,12 +1,12 @@
 { pkgs, config, ... }:
 
 {
-  system.stateVersion = "22.05";
+  system.stateVersion = "22.11";
 
   home-manager.config =
     { pkgs, lib, ... }:
     {
-      home.stateVersion = "22.05";
+      home.stateVersion = "22.11";
       nixpkgs = { inherit (config.nixpkgs) overlays; };
 
       # example config


### PR DESCRIPTION
PR to prepare everything for 22.11.

* The state version is a sensible value that should explicitly set in the users config. Following home-manager: https://github.com/nix-community/home-manager/pull/3043.
* Updating qemu, nix and pinned nixpkgs. Store path to proot updated because not building, see below
* Updating references of 22.05 to 22.11
* Add stateVersion 23.05 (because master after release-22.11 will essentially be 23.05 (also following home-manager's approach)

Currently, bootstrap is not building:

```
$> nix build .#bootstrapZip --impure -L
nix-directory> unpacking sources
nix-directory> unpacking source archive /nix/store/4hk7sv1pdp8ip0ssnk88ri91fd2d9k4p-nix-2.11.1-aarch64-linux.tar.xz
nix-directory> source root is nix-2.11.1-aarch64-linux
nix-directory> setting SOURCE_DATE_EPOCH to timestamp 1663257321 of file nix-2.11.1-aarch64-linux/install-systemd-multi-user.sh
nix-directory> patching sources
nix-directory> configuring
nix-directory> no configure script, doing nothing
nix-directory> building
nix-directory> terminate called after throwing an instance of 'nix::SysError'
nix-directory>   what():  error: reading symbolic link '/proc/self/exe': No such file or directory
error: builder for '/nix/store/5qnqr259jbqsq95lfwc7ln0nh5lb407i-nix-directory.drv' failed with exit code 255;
```

Issue seems to be on `nix-store --init` after nixpkgs update, see https://github.com/t184256/nix-on-droid/blob/master/pkgs/nix-directory.nix#L46