### PR TITLE
Use nix 2.12

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -60,17 +60,17 @@
     },
     "nixpkgs-for-bootstrap": {
       "locked": {
-        "lastModified": 1669834992,
-        "narHash": "sha256-YnhZGHgb4C3Q7DSGisO/stc50jFb9F/MzHeKS4giotg=",
+        "lastModified": 1672946423,
+        "narHash": "sha256-/DoGlsSyAwi0E4wRMjRnNve6yo4x5JlBeyGQRvSrSjs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "596a8e828c5dfa504f91918d0fa4152db3ab5502",
+        "rev": "37d8b66e6acc039dd5d5504aa1fdf0f2847444c5",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "596a8e828c5dfa504f91918d0fa4152db3ab5502",
+        "rev": "37d8b66e6acc039dd5d5504aa1fdf0f2847444c5",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1663932797,
-        "narHash": "sha256-IH8ZBW99W2k7wKLS+Sat9HiKX1TPZjFTnsPizK5crok=",
+        "lastModified": 1672780900,
+        "narHash": "sha256-DxuSn6BdkZapIbg76xzYx1KhVPEZeBexMkt1q/sMVPA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "de3758e31a3a1bc79d569f5deb5dac39791bf9b6",
+        "rev": "54245e1820caabd8a0b53ce4d47e4d0fefe04cd4",
         "type": "github"
       },
       "original": {
@@ -30,11 +30,11 @@
         "nmt": "nmt"
       },
       "locked": {
-        "lastModified": 1666720474,
-        "narHash": "sha256-iWojjDS1D19zpeZXbBdjWb9MiKmVVFQCqtJmtTXgPx8=",
+        "lastModified": 1672673642,
+        "narHash": "sha256-hX0SeBh7sgAoQC/p0u9ittMgiL1nfmP0WWmUrDqzjNA=",
         "owner": "Gerschtli",
         "repo": "nix-formatter-pack",
-        "rev": "14876cc8fe94a3d329964ecb073b4c988c7b61f5",
+        "rev": "5d5b00fe87e506d5f71865f64378cb5683b576b6",
         "type": "github"
       },
       "original": {
@@ -45,11 +45,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1664019863,
-        "narHash": "sha256-nXRRSPr2Jntx2hdZZMkds1fSDNUyw9N/wMtdcQ8VElU=",
+        "lastModified": 1672946423,
+        "narHash": "sha256-/DoGlsSyAwi0E4wRMjRnNve6yo4x5JlBeyGQRvSrSjs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9c64b91d14268cf20ea07ea7930479a75325af9f",
+        "rev": "37d8b66e6acc039dd5d5504aa1fdf0f2847444c5",
         "type": "github"
       },
       "original": {
@@ -93,11 +93,11 @@
     "nmd_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1666190571,
-        "narHash": "sha256-Z1hc7M9X6L+H83o9vOprijpzhTfOBjd0KmUTnpHAVjA=",
+        "lastModified": 1672532617,
+        "narHash": "sha256-Jpblsrf/uPXanYdOh8X3937RzTmFcvszyudFDfEEzgo=",
         "owner": "rycee",
         "repo": "nmd",
-        "rev": "b75d312b4f33bd3294cd8ae5c2ca8c6da2afc169",
+        "rev": "1093ba4ea5b13020474898ebabe4c34496bf8e7d",
         "type": "gitlab"
       },
       "original": {
@@ -133,11 +133,11 @@
     },
     "utils": {
       "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -5,9 +5,9 @@
     nixpkgs.url = "github:NixOS/nixpkgs";
 
     # for bootstrap zip ball creation and proot-termux builds, we use a fixed version of nixpkgs to ease maintanence.
-    # head of nixos-22.11 as of 2022-12-01
+    # head of nixos-22.11 as of 2023-01-05
     # note: when updating nixpkgs-for-bootstrap, update store paths of proot-termux in modules/environment/login/default.nix
-    nixpkgs-for-bootstrap.url = "github:NixOS/nixpkgs/596a8e828c5dfa504f91918d0fa4152db3ab5502";
+    nixpkgs-for-bootstrap.url = "github:NixOS/nixpkgs/37d8b66e6acc039dd5d5504aa1fdf0f2847444c5";
 
     home-manager = {
       url = "github:nix-community/home-manager";

--- a/modules/environment/login/default.nix
+++ b/modules/environment/login/default.nix
@@ -82,7 +82,7 @@ in
     environment.files = {
       inherit login loginInner;
 
-      prootStatic = "/nix/store/8xg8jnaczivjjrd9nq38qvrp9z7avib1-proot-termux-static-aarch64-unknown-linux-android-unstable-2022-05-03";
+      prootStatic = "/nix/store/r3qwl09s14d4axxhqb8sbj5an29vzgin-proot-termux-static-aarch64-unknown-linux-android-unstable-2022-05-03";
     };
 
   };

--- a/modules/environment/login/nix-on-droid.nix.default
+++ b/modules/environment/login/nix-on-droid.nix.default
@@ -27,6 +27,10 @@
   # Backup etc files instead of failing to activate generation if a file already exists in /etc
   environment.etcBackupExtension = ".bak";
 
+  # It is recommended to at least use nix >= 2.12 because of
+  # https://github.com/t184256/nix-on-droid/issues/213
+  nix.package = pkgs.nixVersions.nix_2_12;
+
   # Read the changelog before changing this value
   system.stateVersion = "22.11";
 

--- a/overlays/lib/nixpkgs.nix
+++ b/overlays/lib/nixpkgs.nix
@@ -3,12 +3,12 @@
 { super }:
 
 let
-  # head of nixos-22.11 as of 2022-12-01
+  # head of nixos-22.11 as of 2023-01-05
   pinnedPkgsSrc = super.fetchFromGitHub {
     owner = "NixOS";
     repo = "nixpkgs";
-    rev = "596a8e828c5dfa504f91918d0fa4152db3ab5502";
-    sha256 = "sha256-YnhZGHgb4C3Q7DSGisO/stc50jFb9F/MzHeKS4giotg=";
+    rev = "37d8b66e6acc039dd5d5504aa1fdf0f2847444c5";
+    sha256 = "sha256-/DoGlsSyAwi0E4wRMjRnNve6yo4x5JlBeyGQRvSrSjs=";
   };
 in
 

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -35,6 +35,10 @@ let
         pkgs = pkgs.lib.mkForce pkgs; # to override ./modules/nixpkgs/config.nix
       };
 
+      # It is recommended to at least use nix >= 2.12 because of
+      # https://github.com/t184256/nix-on-droid/issues/213
+      nix.package = pkgs.nixVersions.nix_2_12;
+
       system.stateVersion = "22.11";
 
       # Fix invoking bash after initial build.

--- a/pkgs/nix-directory.nix
+++ b/pkgs/nix-directory.nix
@@ -24,8 +24,8 @@ stdenv.mkDerivation {
   name = "nix-directory";
 
   src = builtins.fetchurl {
-    url = "https://nixos.org/releases/nix/nix-2.11.1/nix-2.11.1-${config.build.arch}-linux.tar.xz";
-    sha256 = "1cvdvka4qs1zx916g23pi9i024sx9h28nv8pvngxh3nk8gm8bvxq";
+    url = "https://nixos.org/releases/nix/nix-2.12.0/nix-2.12.0-${config.build.arch}-linux.tar.xz";
+    sha256 = "sha256:0z302mpihm02cmir74l0ww8r6qznphahnsirx2pg0ackzqscxciq";
   };
 
   PROOT_NO_SECCOMP = 1; # see https://github.com/proot-me/PRoot/issues/106

--- a/templates/advanced/nix-on-droid.nix
+++ b/templates/advanced/nix-on-droid.nix
@@ -27,6 +27,10 @@
   # Backup etc files instead of failing to activate generation if a file already exists in /etc
   environment.etcBackupExtension = ".bak";
 
+  # It is recommended to at least use nix >= 2.12 because of
+  # https://github.com/t184256/nix-on-droid/issues/213
+  nix.package = pkgs.nixVersions.nix_2_12;
+
   # Read the changelog before changing this value
   system.stateVersion = "22.11";
 

--- a/templates/home-manager/nix-on-droid.nix
+++ b/templates/home-manager/nix-on-droid.nix
@@ -27,6 +27,10 @@
   # Backup etc files instead of failing to activate generation if a file already exists in /etc
   environment.etcBackupExtension = ".bak";
 
+  # It is recommended to at least use nix >= 2.12 because of
+  # https://github.com/t184256/nix-on-droid/issues/213
+  nix.package = pkgs.nixVersions.nix_2_12;
+
   # Read the changelog before changing this value
   system.stateVersion = "22.11";
 

--- a/templates/minimal/nix-on-droid.nix
+++ b/templates/minimal/nix-on-droid.nix
@@ -27,6 +27,10 @@
   # Backup etc files instead of failing to activate generation if a file already exists in /etc
   environment.etcBackupExtension = ".bak";
 
+  # It is recommended to at least use nix >= 2.12 because of
+  # https://github.com/t184256/nix-on-droid/issues/213
+  nix.package = pkgs.nixVersions.nix_2_12;
+
   # Read the changelog before changing this value
   system.stateVersion = "22.11";
 


### PR DESCRIPTION
Use nix 2.12 for bootstrap and recommend it in the templates because of #213.

I needed to update the pinned nixpkgs to get nix 2.12.

Fixes #213 