### PR TITLE
modules/environment/path: add environment.extraOutputsToInstall option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Release 23.05 (unreleased)
 
+### New Options
+
+* Add option `environment.extraOutputsToInstall`.
+
 ## Release 22.11
 
 ### Compatibility considerations

--- a/modules/environment/path.nix
+++ b/modules/environment/path.nix
@@ -27,6 +27,13 @@ in
         internal = true;
         description = "Derivation for installing user packages.";
       };
+
+      extraOutputsToInstall = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        example = [ "doc" "info" "devdoc" ];
+        description = "List of additional package outputs to be installed as user packages.";
+      };
     };
 
   };
@@ -70,6 +77,8 @@ in
         name = "nix-on-droid-path";
 
         paths = cfg.packages;
+
+        inherit (cfg) extraOutputsToInstall;
 
         meta = {
           description = "Environment of packages installed through Nix-on-Droid.";


### PR DESCRIPTION
Allow to install extra outputs.

This is useful to e. g. install `info` documentation automatically.

This option was modelled after NixOS's option [environment.extraOutputsToInstall](https://search.nixos.org/options?channel=unstable&show=environment.extraOutputsToInstall&from=0&size=50&sort=relevance&type=packages&query=environment.extraOutputsToInstall).