### PR TITLE
Update GitHub actions and run weekly

### DIFF
--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install nix
-        uses: cachix/install-nix-action@v18
+        uses: cachix/install-nix-action@v20
 
       - name: Setup cachix
         uses: cachix/cachix-action@v12

--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -2,6 +2,8 @@ name: Build bootstrap packages and push to cachix
 on:
   pull_request:
   push:
+  schedule:
+    - cron: 0 0 * * 1
 jobs:
   cachix:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install nix
-        uses: cachix/install-nix-action@v18
+        uses: cachix/install-nix-action@v20
 
       - name: Build docs
         run: |
@@ -48,7 +48,7 @@ jobs:
             public
 
       - name: Setup Pages
-        uses: actions/configure-pages@v2
+        uses: actions/configure-pages@v3
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
@@ -57,4 +57,4 @@ jobs:
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,6 +3,8 @@ name: Build and deploy docs
 on:
   push:
     branches: ["master"]
+  schedule:
+    - cron: 0 0 * * 1
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:

--- a/.github/workflows/fakedroid-odt.yml
+++ b/.github/workflows/fakedroid-odt.yml
@@ -2,6 +2,8 @@ name: Run on-device-tests with fakedroid
 on:
   pull_request:
   push:
+  schedule:
+    - cron: 0 0 * * 1
 jobs:
   fakedroid-odt-channel:
     runs-on: ubuntu-latest

--- a/.github/workflows/fakedroid-odt.yml
+++ b/.github/workflows/fakedroid-odt.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install nix
-        uses: cachix/install-nix-action@v18
+        uses: cachix/install-nix-action@v20
 
       - name: Setup cachix
         uses: cachix/cachix-action@v12
@@ -32,7 +32,6 @@ jobs:
         if: always() && github.event_name != 'pull_request'
         run: nix run --impure .#fakedroid -- nix-shell -p cachix --run 'nix --extra-experimental-features nix-command path-info --all | cachix push nix-on-droid'
 
-
   fakedroid-flakes:
     runs-on: ubuntu-latest
 
@@ -41,7 +40,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install nix
-        uses: cachix/install-nix-action@v18
+        uses: cachix/install-nix-action@v20
 
       - name: Setup cachix
         uses: cachix/cachix-action@v12

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -2,6 +2,8 @@ name: Run lints
 on:
   pull_request:
   push:
+  schedule:
+    - cron: 0 0 * * 1
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install nix
-        uses: cachix/install-nix-action@v18
+        uses: cachix/install-nix-action@v20
 
       - name: Run nix-formatter-pack-check
         run: nix build .#checks.x86_64-linux.nix-formatter-pack-check


### PR DESCRIPTION
Our actions are using outdated versions. This would have become more obvious if we would run our CI regularly. I added a weekly scheduler.