### PR TITLE
nix-on-droid: passthrough --log-format arg

### DIFF
--- a/nix-on-droid/nix-on-droid.sh
+++ b/nix-on-droid/nix-on-droid.sh
@@ -69,6 +69,7 @@ function doHelp() {
     echo "  --max-jobs NUM"
     echo "  --option NAME VALUE"
     echo "  --override-input INPUT URL"
+    echo "  --log-format"
     echo "  --show-trace"
     echo
     echo "Commands"
@@ -167,7 +168,7 @@ while [[ $# -gt 0 ]]; do
             PASSTHROUGH_OPTS+=("$opt" "$1" "$2")
             shift 2
             ;;
-        --builders|--cores|--max-jobs)
+        --builders|--cores|--max-jobs|--log-format)
             PASSTHROUGH_OPTS+=("$opt" "$1")
             shift
             ;;


### PR DESCRIPTION
based on #457.

now you can `nix-on-droid --log-format multiline switch` to see _all_ the things that are currently building, or use `multiline-with-logs` to see the build logs too.