### PR TITLE
Don't use example.org in tests

### DIFF
--- a/tests/emulator/android_integration.py
+++ b/tests/emulator/android_integration.py
@@ -105,14 +105,14 @@ def run(d):
 
     # Verify that *-open* commands work
     for opener in OPENERS:
-        d(f'input text "{opener} https://example.org"')
+        d(f'input text "{opener} https://nix-on-droid.unboiled.info/README.txt"')
         d.ui.press('enter')
         screenshot(d, f'{opener}-opened')
-        wait_for(d, 'This domain is for use in illustrative')
+        wait_for(d, 'This is Nix-on-Droid.')
         screenshot(d, f'{opener}-waited')
         d.ui.press('back')
         screenshot(d, f'{opener}-back')
-        wait_for(d, f'{opener} https://example.org')
+        wait_for(d, f'{opener} https://nix-on-droid.unboiled.info/README.txt')
 
     # test termux-wake-lock/termux-wake-unlock
     d.ui.open_notification()


### PR DESCRIPTION
The text at example.org was recently changed, which breaks the emulator tests. There is now a request there to "Avoid use in operations", so using something else in the tests seems like the friendly thing to do.

(checking if the test actually passes in CI before I unmark this as draft...)