### PR TITLE
Fixed-Output Derivation for Bootstrap Tarball

### DIFF
--- a/pkgs/nix-directory.nix
+++ b/pkgs/nix-directory.nix
@@ -8,6 +8,7 @@
 , proot
 , pkgsStatic
 , system
+, fetchurl
 }:
 
 let
@@ -38,13 +39,13 @@ in
 stdenvNoCC.mkDerivation {
   name = "nix-directory";
 
-  src = builtins.fetchurl {
+  src = fetchurl {
     url = "https://nixos.org/releases/nix/nix-2.31.2/nix-2.31.2-${system}.tar.xz";
     sha256 =
       let
         nixShas = {
-          aarch64-linux = "sha256:0mh4aqzx4dzf1m80al2ffx5p2axcwn2qzxzq9f5p2v892a255nv4";
-          x86_64-linux = "sha256:0q4azlxwqvzrad4bgbwggvm7lc4waawvy25sci4225nhxs37rxni";
+          aarch64-linux = "0mh4aqzx4dzf1m80al2ffx5p2axcwn2qzxzq9f5p2v892a255nv4";
+          x86_64-linux = "0q4azlxwqvzrad4bgbwggvm7lc4waawvy25sci4225nhxs37rxni";
         };
       in
       nixShas.${system};


### PR DESCRIPTION
Makes the Nix tarball download in bootstrap package build reproducible and deterministic by using Fixed-Output Derivations (FOD) - instead of impure `builtins.fetchurl`.
