### PR TITLE
add cachix to flake.nix nixConfig

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -156,4 +156,9 @@
         };
       };
     };
+
+  nixConfig = {
+    extra-substituters = [ "https://nix-on-droid.cachix.org" ];
+    extra-trusted-public-keys = [ "nix-on-droid.cachix.org-1:56snoMJTXmDRC1Ei24CmKoUqvHJ9XCp+nidK7qkMQrU=" ];
+  };
 }


### PR DESCRIPTION
Configure https://app.cachix.org/cache/nix-on-droid in flake.nix

Allows building with `--accept-flake-config` (or manually accepting when prompted) to automatically use substituter